### PR TITLE
GS-57: Scheduled Job to Rebuild Cache 

### DIFF
--- a/CRM/Activityreport/Page/ActivityReport.php
+++ b/CRM/Activityreport/Page/ActivityReport.php
@@ -3,9 +3,24 @@
 require_once 'CRM/Core/Page.php';
 
 class CRM_Activityreport_Page_ActivityReport extends CRM_Core_Page {
-  function run() {
-    CRM_Utils_System::setTitle(ts('ActivityReport'));
+
+  public function run() {
+    CRM_Utils_System::setTitle(ts('Activity Report'));
+
+    $this->assign('cacheBuilt', $this->isCacheBuilt());
 
     parent::run();
   }
+
+  /**
+   * Checks if cache for the entity is built.
+   *
+   * @return bool
+   *   True if the cache is already built, false otherwise
+   */
+  private function isCacheBuilt() {
+    $cacheGroup = new CRM_PivotCache_GroupActivity();
+    return $cacheGroup->isCacheBuilt();
+  }
+
 }

--- a/CRM/PivotCache/AbstractGroup.php
+++ b/CRM/PivotCache/AbstractGroup.php
@@ -45,7 +45,8 @@ abstract class CRM_PivotCache_AbstractGroup implements CRM_PivotCache_GroupInter
    * @inheritdoc
    */
   public function cacheHeader(array $rows) {
-    CRM_Core_BAO_Cache::setItem(json_encode($this->sortHeader($rows)), $this->getName(), 'header');
+    $jsonHeader = json_encode($this->sortHeader($rows));
+    CRM_Core_BAO_Cache::setItem($jsonHeader, $this->getName(), 'header');
   }
 
   /**
@@ -72,7 +73,8 @@ abstract class CRM_PivotCache_AbstractGroup implements CRM_PivotCache_GroupInter
   public function cachePage(DataPage $page) {
     $count = count($page->getData());
 
-    CRM_Core_BAO_Cache::setItem(json_encode($page->getData()), $this->getName(), $this->getPath($page->getIndex(), $page->getPage()));
+    $jsonData = json_encode($page->getData());
+    CRM_Core_BAO_Cache::setItem($jsonData, $this->getName(), $this->getPath($page->getIndex(), $page->getPage()));
 
     return $count;
   }

--- a/CRM/PivotCache/AbstractGroup.php
+++ b/CRM/PivotCache/AbstractGroup.php
@@ -90,4 +90,27 @@ abstract class CRM_PivotCache_AbstractGroup implements CRM_PivotCache_GroupInter
   protected function getPath($index, $page = NULL) {
     return 'data_' . $index . '_' . str_pad($page, 6, '0', STR_PAD_LEFT);
   }
+
+
+  /**
+   * Checks if cache for the entity is built.
+   *
+   * @return bool
+   *   True if there is data in cache for the entity, false otherwise
+   */
+  public function isCacheBuilt() {
+    $cache = new CRM_Core_DAO_Cache();
+
+    $cache->group_name = $this->getName();
+    $cache->whereAdd("path = 'header'");
+    $cache->orderBy('path ASC');
+    $cache->find();
+
+    if ($cache->N > 0) {
+      return true;
+    }
+
+    return false;
+  }
+
 }

--- a/templates/CRM/Activityreport/Page/ActivityReport.tpl
+++ b/templates/CRM/Activityreport/Page/ActivityReport.tpl
@@ -1,5 +1,13 @@
 <h3>Activity Pivot Table</h3>
 
+{if !$cacheBuilt}
+  <div class="messages error">
+    This report works using a cache built with activities' data, but the cache
+    has not been built yet. If you want to load the activity information into
+    the report, click on the 'Build Cache' button to start working.
+  </div>
+{/if}
+
 <div id="activity-report-preloader">
   Loading<span id="activity-report-loading-count"></span>.
 </div>
@@ -11,6 +19,7 @@
     <input type="text" name="activity_end_date" value="">
     <input class="apply-filters-button" type="button" value="Apply filters">
     <input class="load-all-data-button hidden" type="button" value="Load all data">
+    <input class="build-cache-button hidden" type="button" value="{if !$cacheBuilt}Build Cache{else}Rebuild Cache{/if}">
   </form>
 </div>
 <div id="activity-report-pivot-table">
@@ -119,6 +128,13 @@
           });
         });
 
+        $('input[type="button"].build-cache-button', activityReportForm).click(function(e) {
+          CRM.confirm({message: 'This operation may take some time to build the cache. Do you really want to build the cache for Activities\' data?' })
+          .on('crmConfirm:yes', function() {
+            CRM.api3('ActivityReport', 'rebuildcache', {}).done(initialDataLoad);
+          });
+        });
+
         activityReportStartDateInput.crmDatepicker({
           time: false
         });
@@ -128,32 +144,36 @@
 
         // Initially we load header and check total number of Activities
         // and then start data fetching.
-        CRM.api3('ActivityReport', 'getheader', {
-        }).done(function(result) {
-          header = result.values;
-
-          CRM.api3('Activity', 'getcount', {
-            "sequential": 1,
-            "is_current_revision": 1,
-            "is_deleted": 0,
-            "is_test": 0,
+        function initialDataLoad() {
+          CRM.api3('ActivityReport', 'getheader', {
           }).done(function(result) {
-            total = parseInt(result.result, 10);
+            header = result.values;
 
-            if (total > 5000) {
-              CRM.alert('There are more than 5000 Activities, getting only Activities from last 30 days.', '', 'info');
+            CRM.api3('Activity', 'getcount', {
+              "sequential": 1,
+              "is_current_revision": 1,
+              "is_deleted": 0,
+              "is_test": 0,
+            }).done(function(result) {
+              total = parseInt(result.result, 10);
 
-              $('input[type="button"].load-all-data-button', activityReportForm).removeClass('hidden');
-              var startDateFilterValue = new Date();
-              var endDateFilterValue = new Date();
-              startDateFilterValue.setDate(startDateFilterValue.getDate() - 30);
+              if (total > 5000) {
+                CRM.alert('There are more than 5000 Activities, getting only Activities from last 30 days.', '', 'info');
 
-              loadDataByDateFilter(startDateFilterValue.toISOString().substring(0, 10), endDateFilterValue.toISOString().substring(0, 10));
-            } else {
-              loadAllData();
-            }
+                $('input[type="button"].load-all-data-button', activityReportForm).removeClass('hidden');
+                var startDateFilterValue = new Date();
+                var endDateFilterValue = new Date();
+                startDateFilterValue.setDate(startDateFilterValue.getDate() - 30);
+
+                loadDataByDateFilter(startDateFilterValue.toISOString().substring(0, 10), endDateFilterValue.toISOString().substring(0, 10));
+              } else {
+                loadAllData();
+              }
+            });
           });
-        });
+        }
+
+        initialDataLoad();
 
         /**
          * Run data loading by specified start and end date values.


### PR DESCRIPTION
## Overview
The system should automatically create and rebuild cache for all reports.

## Before
Although there was an API call that can be used to rebuild the report's cache, there was no way for users to use it.

![image](https://user-images.githubusercontent.com/21999940/30711783-6ab99378-9ecf-11e7-97e1-0a1ac40abf7c.png)

## After

1. A scheduled job was created to run daily, rebuilding the cache.
1. A button was added to the report's form so the user can rebuild the cache manually
1. A warning message was implemented to inform the user when the report's cache is not built

![image](https://user-images.githubusercontent.com/21999940/30711803-86089f84-9ecf-11e7-9777-c12d28e4d511.png)
