### PR TITLE
GS-57: Cache Rebuilding for All Entities

### DIFF
--- a/CRM/Activityreport/Page/ActivityReport.php
+++ b/CRM/Activityreport/Page/ActivityReport.php
@@ -3,6 +3,7 @@
 require_once 'CRM/Core/Page.php';
 
 class CRM_Activityreport_Page_ActivityReport extends CRM_Core_Page {
+
   function run() {
     CRM_Utils_System::setTitle(ts('Activity Report'));
 
@@ -13,8 +14,20 @@ class CRM_Activityreport_Page_ActivityReport extends CRM_Core_Page {
     );
     $this->assign('options_array', $options_array);
     $this->assign('CRMDataType', 'Activity');
+    $this->assign('cacheBuilt', $this->isCacheBuilt());
 
     parent::run();
+  }
+
+  /**
+   * Checks if cache for the entity is built.
+   *
+   * @return bool
+   *   True if the cache is already built, false otherwise
+   */
+  private function isCacheBuilt() {
+    $cacheGroup = new CRM_PivotCache_GroupActivity();
+    return $cacheGroup->isCacheBuilt();
   }
 
 }

--- a/CRM/Activityreport/Page/ContributionReport.php
+++ b/CRM/Activityreport/Page/ContributionReport.php
@@ -13,8 +13,20 @@ class CRM_Activityreport_Page_ContributionReport extends CRM_Core_Page {
     );
     $this->assign('options_array', $options_array);
     $this->assign('CRMDataType', 'Contribution');
+    $this->assign('cacheBuilt', $this->isCacheBuilt());
 
     parent::run();
+  }
+
+  /**
+   * Checks if cache for the entity is built.
+   *
+   * @return bool
+   *   True if the cache is already built, false otherwise
+   */
+  private function isCacheBuilt() {
+    $cacheGroup = new CRM_PivotCache_GroupContribution();
+    return $cacheGroup->isCacheBuilt();
   }
 
 }

--- a/CRM/Activityreport/Page/MembershipReport.php
+++ b/CRM/Activityreport/Page/MembershipReport.php
@@ -13,8 +13,20 @@ class CRM_Activityreport_Page_MembershipReport extends CRM_Core_Page {
     );
     $this->assign('options_array', $options_array);
     $this->assign('CRMDataType', $options_array);
+    $this->assign('cacheBuilt', $this->isCacheBuilt());
 
     parent::run();
+  }
+
+  /**
+   * Checks if cache for the entity is built.
+   *
+   * @return bool
+   *   True if the cache is already built, false otherwise
+   */
+  private function isCacheBuilt() {
+    $cacheGroup = new CRM_PivotCache_GroupMembership();
+    return $cacheGroup->isCacheBuilt();
   }
 
 }

--- a/CRM/PivotCache/AbstractGroup.php
+++ b/CRM/PivotCache/AbstractGroup.php
@@ -45,7 +45,8 @@ abstract class CRM_PivotCache_AbstractGroup implements CRM_PivotCache_GroupInter
    * @inheritdoc
    */
   public function cacheHeader(array $rows) {
-    CRM_Core_BAO_Cache::setItem(json_encode($this->sortHeader($rows)), $this->getName(), 'header');
+    $jsonHeader = json_encode($this->sortHeader($rows));
+    CRM_Core_BAO_Cache::setItem($jsonHeader, $this->getName(), 'header');
   }
 
   /**
@@ -72,7 +73,8 @@ abstract class CRM_PivotCache_AbstractGroup implements CRM_PivotCache_GroupInter
   public function cachePage(DataPage $page) {
     $count = count($page->getData());
 
-    CRM_Core_BAO_Cache::setItem(json_encode($page->getData()), $this->getName(), $this->getPath($page->getIndex(), $page->getPage()));
+    $jsonData = json_encode($page->getData());
+    CRM_Core_BAO_Cache::setItem($jsonData, $this->getName(), $this->getPath($page->getIndex(), $page->getPage()));
 
     return $count;
   }

--- a/CRM/PivotCache/AbstractGroup.php
+++ b/CRM/PivotCache/AbstractGroup.php
@@ -90,4 +90,27 @@ abstract class CRM_PivotCache_AbstractGroup implements CRM_PivotCache_GroupInter
   protected function getPath($index, $page = NULL) {
     return 'data_' . $index . '_' . str_pad($page, 6, '0', STR_PAD_LEFT);
   }
+
+
+  /**
+   * Checks if cache for the entity is built.
+   *
+   * @return bool
+   *   True if there is data in cache for the entity, false otherwise
+   */
+  public function isCacheBuilt() {
+    $cache = new CRM_Core_DAO_Cache();
+
+    $cache->group_name = $this->getName();
+    $cache->whereAdd("path = 'header'");
+    $cache->orderBy('path ASC');
+    $cache->find();
+
+    if ($cache->N > 0) {
+      return true;
+    }
+
+    return false;
+  }
+
 }

--- a/CRM/PivotCache/AbstractGroup.php
+++ b/CRM/PivotCache/AbstractGroup.php
@@ -19,6 +19,22 @@ abstract class CRM_PivotCache_AbstractGroup implements CRM_PivotCache_GroupInter
   }
 
   /**
+   * Returns instance of data class for given entity.
+   *
+   * @param string $entity
+   *   Name of entity
+   *
+   * @return \CRM_PivotReport_AbstractData
+   */
+  public static function getInstance($entity) {
+
+    $className = 'CRM_PivotCache_Group' . $entity;
+    $dataInstance = new $className();
+
+    return $dataInstance;
+  }
+
+  /**
    * Gets cache group name.
    *
    * @return string
@@ -103,6 +119,7 @@ abstract class CRM_PivotCache_AbstractGroup implements CRM_PivotCache_GroupInter
 
     $cache->group_name = $this->getName();
     $cache->whereAdd("path = 'header'");
+    $cache->whereAdd("group_name = '{$this->getName()}'");
     $cache->orderBy('path ASC');
     $cache->find();
 

--- a/CRM/PivotReport/AbstractData.php
+++ b/CRM/PivotReport/AbstractData.php
@@ -85,6 +85,22 @@ abstract class CRM_PivotReport_AbstractData implements CRM_PivotReport_DataInter
   }
 
   /**
+   * Returns instance of data class for given entity.
+   *
+   * @param string $entity
+   *   Name of entity
+   *
+   * @return \CRM_PivotReport_AbstractData
+   */
+  public static function getInstance($entity) {
+
+    $className = 'CRM_PivotReport_Data' . $entity;
+    $dataInstance = new $className();
+
+    return $dataInstance;
+  }
+
+  /**
    * @inheritdoc
    */
   public function get(AbstractGroup $cacheGroup, array $params, $page = 0) {

--- a/api/v3/ActivityReport.php
+++ b/api/v3/ActivityReport.php
@@ -92,38 +92,26 @@ function civicrm_api3_activity_report_rebuildcache($params) {
   $startDate = !empty($params['start_date']) ? $params['start_date'] : null;
   $endDate = !empty($params['end_date']) ? $params['end_date'] : null;
 
-  $dataInstance = new CRM_PivotReport_DataActivity();
-  $cacheGroupInstance = new CRM_PivotCache_GroupActivity();
-  $activities = $dataInstance->rebuildCache(
-    $cacheGroupInstance,
-    array(
-      'start_date' => $startDate,
-      'end_date' => $endDate,
-    )
-  );
+  if (isset($params['entity'])) {
+    $entities = array($params['entity']);
+  } else {
+    $entities = array('Activity', 'Contribution', 'Membership');
+  }
 
-  $dataInstance = new CRM_PivotReport_DataContribution();
-  $cacheGroupInstance = new CRM_PivotCache_GroupContribution();
-  $contributions = $dataInstance->rebuildCache(
-    $cacheGroupInstance,
-    array(
-    )
-  );
-
-  $dataInstance = new CRM_PivotReport_DataMembership();
-  $cacheGroupInstance = new CRM_PivotCache_GroupMembership();
-  $memberships = $dataInstance->rebuildCache(
-    $cacheGroupInstance,
-    array(
-    )
-  );
+  foreach ($entities as $currentEntity) {
+    $dataInstance = CRM_PivotReport_AbstractData::getInstance($currentEntity);
+    $cacheGroupInstance = CRM_PivotCache_AbstractGroup::getInstance($currentEntity);
+    $result[$currentEntity] = $dataInstance->rebuildCache(
+      $cacheGroupInstance,
+      array(
+        'start_date' => $startDate,
+        'end_date' => $endDate,
+      )
+    );
+  }
 
   return civicrm_api3_create_success(
-    array(
-      'activities' => $activities,
-      'contributions' => $contributions,
-      'memberships' => $memberships
-    ),
+    $result,
     $params
   );
 }

--- a/templates/CRM/Activityreport/Page/ActivityReport.tpl
+++ b/templates/CRM/Activityreport/Page/ActivityReport.tpl
@@ -13,7 +13,6 @@
     <input type="text" name="activity_end_date" value="">
     <input class="apply-filters-button" type="button" value="Apply filters">
     <input class="load-all-data-button hidden" type="button" value="Load all data">
-    <input class="build-cache-button hidden" type="button" value="{if !$cacheBuilt}Build Cache{else}Rebuild Cache{/if}">
   </form>
 </div>
 <div id="activity-report-pivot-table">
@@ -122,10 +121,10 @@
           });
         });
 
-        $('input[type="button"].build-cache-button', activityReportForm).click(function(e) {
+        $('input[type="button"].build-cache-button').click(function(e) {
           CRM.confirm({message: 'This operation may take some time to build the cache. Do you really want to build the cache for Activities\' data?' })
           .on('crmConfirm:yes', function() {
-            CRM.api3('ActivityReport', 'rebuildcache', {}).done(initialDataLoad);
+            CRM.api3('ActivityReport', 'rebuildcache', {entity: 'Activity'}).done(initialDataLoad);
           });
         });
 
@@ -166,7 +165,6 @@
             });
           });
         }
-
         initialDataLoad();
 
         /**

--- a/templates/CRM/Activityreport/Page/ActivityReport.tpl
+++ b/templates/CRM/Activityreport/Page/ActivityReport.tpl
@@ -1,5 +1,7 @@
 <h3>Activity Pivot Table</h3>
+
 {include file="CRM/Activityreport/Page/ReportSelector.tpl"}
+
 <div id="activity-report-preloader">
   Loading<span id="activity-report-loading-count"></span>.
 </div>
@@ -11,6 +13,7 @@
     <input type="text" name="activity_end_date" value="">
     <input class="apply-filters-button" type="button" value="Apply filters">
     <input class="load-all-data-button hidden" type="button" value="Load all data">
+    <input class="build-cache-button hidden" type="button" value="{if !$cacheBuilt}Build Cache{else}Rebuild Cache{/if}">
   </form>
 </div>
 <div id="activity-report-pivot-table">
@@ -119,6 +122,13 @@
           });
         });
 
+        $('input[type="button"].build-cache-button', activityReportForm).click(function(e) {
+          CRM.confirm({message: 'This operation may take some time to build the cache. Do you really want to build the cache for Activities\' data?' })
+          .on('crmConfirm:yes', function() {
+            CRM.api3('ActivityReport', 'rebuildcache', {}).done(initialDataLoad);
+          });
+        });
+
         activityReportStartDateInput.crmDatepicker({
           time: false
         });
@@ -128,32 +138,36 @@
 
         // Initially we load header and check total number of Activities
         // and then start data fetching.
-        CRM.api3('ActivityReport', 'getheader', {
-        }).done(function(result) {
-          header = result.values;
-
-          CRM.api3('Activity', 'getcount', {
-            "sequential": 1,
-            "is_current_revision": 1,
-            "is_deleted": 0,
-            "is_test": 0,
+        function initialDataLoad() {
+          CRM.api3('ActivityReport', 'getheader', {
           }).done(function(result) {
-            total = parseInt(result.result, 10);
+            header = result.values;
 
-            if (total > 5000) {
-              CRM.alert('There are more than 5000 Activities, getting only Activities from last 30 days.', '', 'info');
+            CRM.api3('Activity', 'getcount', {
+              "sequential": 1,
+              "is_current_revision": 1,
+              "is_deleted": 0,
+              "is_test": 0,
+            }).done(function(result) {
+              total = parseInt(result.result, 10);
 
-              $('input[type="button"].load-all-data-button', activityReportForm).removeClass('hidden');
-              var startDateFilterValue = new Date();
-              var endDateFilterValue = new Date();
-              startDateFilterValue.setDate(startDateFilterValue.getDate() - 30);
+              if (total > 5000) {
+                CRM.alert('There are more than 5000 Activities, getting only Activities from last 30 days.', '', 'info');
 
-              loadDataByDateFilter(startDateFilterValue.toISOString().substring(0, 10), endDateFilterValue.toISOString().substring(0, 10));
-            } else {
-              loadAllData();
-            }
+                $('input[type="button"].load-all-data-button', activityReportForm).removeClass('hidden');
+                var startDateFilterValue = new Date();
+                var endDateFilterValue = new Date();
+                startDateFilterValue.setDate(startDateFilterValue.getDate() - 30);
+
+                loadDataByDateFilter(startDateFilterValue.toISOString().substring(0, 10), endDateFilterValue.toISOString().substring(0, 10));
+              } else {
+                loadAllData();
+              }
+            });
           });
-        });
+        }
+
+        initialDataLoad();
 
         /**
          * Run data loading by specified start and end date values.

--- a/templates/CRM/Activityreport/Page/ContributionReport.tpl
+++ b/templates/CRM/Activityreport/Page/ContributionReport.tpl
@@ -110,6 +110,13 @@
         });
       });
 
+      $('input[type="button"].build-cache-button').click(function(e) {
+        CRM.confirm({message: 'This operation may take some time to build the cache. Do you really want to build the cache for Activities\' data?' })
+        .on('crmConfirm:yes', function() {
+          CRM.api3('ActivityReport', 'rebuildcache', {entity: 'Contribution'}).done(initialDataLoad);
+        });
+      });
+
       activityReportStartDateInput.crmDatepicker({
         time: false
       });
@@ -119,33 +126,34 @@
 
       // Initially we load header and check total number of Activities
       // and then start data fetching.
-      CRM.api3('ActivityReport', 'getheader', {
-        'entity': 'Contribution'
-      }).done(function(result) {
-        header = result.values;
-
-        CRM.api3('Activity', 'getcount', {
-          "sequential": 1,
-          "is_current_revision": 1,
-          "is_deleted": 0,
-          "is_test": 0,
+      function initialDataLoad() {
+        CRM.api3('ActivityReport', 'getheader', {
+          'entity': 'Contribution'
         }).done(function(result) {
-          total = parseInt(result.result, 10);
+          header = result.values;
 
-          if (total > 5000) {
-            CRM.alert('There are more than 5000 Activities, getting only Activities from last 30 days.', '', 'info');
+          CRM.api3('Contribution', 'getcount', {
+            "sequential": 1,
+            "is_test": 0,
+          }).done(function(result) {
+            total = parseInt(result.result, 10);
 
-            $('input[type="button"].load-all-data-button', activityReportForm).removeClass('hidden');
-            var startDateFilterValue = new Date();
-            var endDateFilterValue = new Date();
-            startDateFilterValue.setDate(startDateFilterValue.getDate() - 30);
+            if (total > 5000) {
+              CRM.alert('There are more than 5000 Contributions, getting only from last 30 days.', '', 'info');
 
-            loadDataByDateFilter(startDateFilterValue.toISOString().substring(0, 10), endDateFilterValue.toISOString().substring(0, 10));
-          } else {
-            loadAllData();
-          }
+              $('input[type="button"].load-all-data-button', activityReportForm).removeClass('hidden');
+              var startDateFilterValue = new Date();
+              var endDateFilterValue = new Date();
+              startDateFilterValue.setDate(startDateFilterValue.getDate() - 30);
+
+              loadDataByDateFilter(startDateFilterValue.toISOString().substring(0, 10), endDateFilterValue.toISOString().substring(0, 10));
+            } else {
+              loadAllData();
+            }
+          });
         });
-      });
+      }
+      initialDataLoad();
 
       /**
        * Run data loading by specified start and end date values.

--- a/templates/CRM/Activityreport/Page/MembershipReport.tpl
+++ b/templates/CRM/Activityreport/Page/MembershipReport.tpl
@@ -110,6 +110,13 @@
         });
       });
 
+      $('input[type="button"].build-cache-button').click(function(e) {
+        CRM.confirm({message: 'This operation may take some time to build the cache. Do you really want to build the cache for Activities\' data?' })
+        .on('crmConfirm:yes', function() {
+          CRM.api3('ActivityReport', 'rebuildcache', {entity: 'Membership'}).done(initialDataLoad);
+        });
+      });
+
       activityReportStartDateInput.crmDatepicker({
         time: false
       });
@@ -119,33 +126,33 @@
 
       // Initially we load header and check total number of Activities
       // and then start data fetching.
-      CRM.api3('ActivityReport', 'getheader', {
-        'entity': 'Membership'
-      }).done(function(result) {
-        header = result.values;
-
-        CRM.api3('Activity', 'getcount', {
-          "sequential": 1,
-          "is_current_revision": 1,
-          "is_deleted": 0,
-          "is_test": 0,
+      function initialDataLoad() {
+        CRM.api3('ActivityReport', 'getheader', {
+          'entity': 'Membership'
         }).done(function(result) {
-          total = parseInt(result.result, 10);
+          header = result.values;
 
-          if (total > 5000) {
-            CRM.alert('There are more than 5000 Activities, getting only Activities from last 30 days.', '', 'info');
+          CRM.api3('Membership', 'getcount', {
+            "sequential": 1,
+          }).done(function(result) {
+            total = parseInt(result.result, 10);
 
-            $('input[type="button"].load-all-data-button', activityReportForm).removeClass('hidden');
-            var startDateFilterValue = new Date();
-            var endDateFilterValue = new Date();
-            startDateFilterValue.setDate(startDateFilterValue.getDate() - 30);
+            if (total > 5000) {
+              CRM.alert('There are more than Memberships, getting only Memberships from last 30 days.', '', 'info');
 
-            loadDataByDateFilter(startDateFilterValue.toISOString().substring(0, 10), endDateFilterValue.toISOString().substring(0, 10));
-          } else {
-            loadAllData();
-          }
+              $('input[type="button"].load-all-data-button', activityReportForm).removeClass('hidden');
+              var startDateFilterValue = new Date();
+              var endDateFilterValue = new Date();
+              startDateFilterValue.setDate(startDateFilterValue.getDate() - 30);
+
+              loadDataByDateFilter(startDateFilterValue.toISOString().substring(0, 10), endDateFilterValue.toISOString().substring(0, 10));
+            } else {
+              loadAllData();
+            }
+          });
         });
-      });
+      }
+      initialDataLoad();
 
       /**
        * Run data loading by specified start and end date values.

--- a/templates/CRM/Activityreport/Page/ReportSelector.tpl
+++ b/templates/CRM/Activityreport/Page/ReportSelector.tpl
@@ -25,6 +25,14 @@
 </script>
 {/literal}
 
+{if !$cacheBuilt}
+  <div class="messages error">
+    This report works using a cache built with activities' data, but the cache
+    has not been built yet. If you want to load the activity information into
+    the report, click on the 'Build Cache' button to start working.
+  </div>
+{/if}
+
 <form id="whichDataType" method="post">
   Select which CiviCRM data do you want to use? (<em>default: Contribution</em>)
   <select name="CRMData" id="CRMData">

--- a/templates/CRM/Activityreport/Page/ReportSelector.tpl
+++ b/templates/CRM/Activityreport/Page/ReportSelector.tpl
@@ -27,9 +27,9 @@
 
 {if !$cacheBuilt}
   <div class="messages error">
-    This report works using a cache built with activities' data, but the cache
-    has not been built yet. If you want to load the activity information into
-    the report, click on the 'Build Cache' button to start working.
+    This report works using a cache built with data in CiviCRM, but the cache
+    has not been built yet. If you want to load the information into the report,
+    click on the 'Build Cache' button to start working.
   </div>
 {/if}
 
@@ -39,4 +39,5 @@
     {html_options options=$options_array selected=$CRMDataType}
   </select>
   <input id="reportSelectorBtn" type="button" value="Go"/>
+  <input class="build-cache-button hidden" type="button" value="{if !$cacheBuilt}Build Cache{else}Rebuild Cache{/if}">
 </form>


### PR DESCRIPTION
## Overview
The system should automatically create and rebuild cache for reports of all entities.

## Before
Although there was an API call that can be used to rebuild the report's cache, there was no way for users to use it. Job and button to rebuild cache were created based on develop branch and merged on PR #29, but it only works for activities. This needs to be applied to all entities.

## After
Scheduled job and form button to rebuild cache works for all report entities.

1. A scheduled job was created to run daily, rebuilding the cache.
1. A button was added to the report's form so the user can rebuild the cache manually
1. A warning message was implemented to inform the user when the report's cache is not built
