### PR TITLE
GS-55: Add Date Fields Grouped by Month

### DIFF
--- a/CRM/PivotReport/AbstractData.php
+++ b/CRM/PivotReport/AbstractData.php
@@ -80,8 +80,19 @@ abstract class CRM_PivotReport_AbstractData implements CRM_PivotReport_DataInter
    */
   protected $name = NULL;
 
-  public function __construct($name = NULL) {
+  /**
+   * CRM_PivotReport_AbstractData constructor.
+   *
+   * @param string $name
+   */
+  public function __construct($name) {
     $this->name = $name;
+
+    $dateFields = $this->getDateFields();
+
+    foreach ($dateFields as $field) {
+      $this->additionalHeaderFields[$field . ' (' . ts('per month') . ')'] = '';
+    }
   }
 
   /**

--- a/CRM/PivotReport/DataActivity.php
+++ b/CRM/PivotReport/DataActivity.php
@@ -6,16 +6,13 @@
 class CRM_PivotReport_DataActivity extends CRM_PivotReport_AbstractData {
 
   /**
-   * @inheritdoc
+   * CRM_PivotReport_DataActivity constructor.
    */
-  protected $additionalHeaderFields = array(
-    'Activity Date' => null,
-    'Activity Start Date Months' => null,
-    'Activity Expire Date' => null,
-  );
+  public function __construct() {
+    parent::__construct('Activity');
 
-  public function __construct($name = NULL) {
-    $this->name = 'Activity';
+    $this->additionalHeaderFields['Activity Date'] = null;
+    $this->additionalHeaderFields['Activity Expire Date'] = null;
   }
 
   /**

--- a/CRM/PivotReport/DataContribution.php
+++ b/CRM/PivotReport/DataContribution.php
@@ -6,17 +6,10 @@
 class CRM_PivotReport_DataContribution extends CRM_PivotReport_AbstractData {
 
   /**
-   * @inheritdoc
+   * CRM_PivotReport_DataContribution constructor.
    */
-  protected $additionalHeaderFields = array(
-    'Date-wise Reciepts' => '',
-    'Day-wise Reciepts' => '',
-    'Month-wise Reciepts' => '',
-    'Year-wise Reciepts' => '',
-  );
-
   public function __construct() {
-    $this->name = 'Contribution';
+    parent::__construct('Contribution');
   }
 
   /**

--- a/CRM/PivotReport/DataMembership.php
+++ b/CRM/PivotReport/DataMembership.php
@@ -6,17 +6,10 @@
 class CRM_PivotReport_DataMembership extends CRM_PivotReport_AbstractData {
 
   /**
-   * @inheritdoc
+   * CRM_PivotReport_DataMembership constructor.
    */
-  protected $additionalHeaderFields = array(
-    'Date-wise New Members' => '',
-    'Day-wise New Members' => '',
-    'Month-wise New Members' => '',
-    'Year-wise New Members' => '',
-  );
-
   public function __construct() {
-    $this->name = 'Membership';
+    parent::__construct('Membership');
   }
 
   /**
@@ -38,18 +31,6 @@ class CRM_PivotReport_DataMembership extends CRM_PivotReport_AbstractData {
     );
 
     return $params;
-  }
-
-  /**
-   * @inheritdoc
-   */
-  protected function setCustomValue($key, $value) {
-    $result = $value;
-
-    switch ($key) {
-    }
-
-    $this->customizedValues[$key][$value] = $result;
   }
 
   /**

--- a/js/PivotReport.PivotTable.js
+++ b/js/PivotReport.PivotTable.js
@@ -607,6 +607,10 @@ CRM.PivotReport.PivotTable = (function($) {
       that.total = parseInt(result.getCount.result, 10);
       that.crmConfig = result.getConfig.values[0];
 
+      $.each(that.dateFields, function (i, value) {
+        that.config.derivedAttributes[value + ' (' + ts('per month') + ')'] = $.pivotUtilities.derivers.dateFormat(value, '%y-%m')
+      });
+
       if (that.config.initialLoad.limit && that.total > that.config.initialLoad.limit) {
         CRM.alert(that.config.initialLoad.message, '', 'info');
 

--- a/templates/CRM/Activityreport/Page/ActivityReport.tpl
+++ b/templates/CRM/Activityreport/Page/ActivityReport.tpl
@@ -62,7 +62,6 @@
         },
         'derivedAttributes': {
           'Activity Date': $.pivotUtilities.derivers.dateFormat('Activity Date Time', '%y-%m-%d'),
-          'Activity Start Date Months': $.pivotUtilities.derivers.dateFormat('Activity Date Time', '%y-%m'),
           'Activity Expire Date': function(row) {
             if (!row['Expire Date']) {
               return '';

--- a/templates/CRM/Activityreport/Page/ContributionReport.tpl
+++ b/templates/CRM/Activityreport/Page/ContributionReport.tpl
@@ -3,12 +3,6 @@
     CRM.$(function ($) {
       new CRM.PivotReport.PivotTable({
         'entityName': 'Contribution',
-        'derivedAttributes': {
-          'Date-wise Reciepts': $.pivotUtilities.derivers.dateFormat("Date Received", "%d"),
-          'Day-wise Reciepts': $.pivotUtilities.derivers.dateFormat("Date Received", "%w"),
-          'Month-wise Reciepts': $.pivotUtilities.derivers.dateFormat("Date Received", "%n"),
-          'Year-wise Reciepts': $.pivotUtilities.derivers.dateFormat("Date Received", "%y"),
-        }
       });
     });
 </script>

--- a/templates/CRM/Activityreport/Page/MembershipReport.tpl
+++ b/templates/CRM/Activityreport/Page/MembershipReport.tpl
@@ -3,12 +3,6 @@
     CRM.$(function ($) {
       new CRM.PivotReport.PivotTable({
         'entityName': 'Membership',
-        'derivedAttributes': {
-          'Date-wise New Members': $.pivotUtilities.derivers.dateFormat("Member Since", "%d"),
-          'Day-wise New Members': $.pivotUtilities.derivers.dateFormat("Member Since", "%w"),
-          'Month-wise New Members': $.pivotUtilities.derivers.dateFormat("Member Since", "%n"),
-          'Year-wise New Members': $.pivotUtilities.derivers.dateFormat("Member Since", "%y"),
-        }
       });
     });
 </script>


### PR DESCRIPTION
## Overview
All date type fields on the pivot table should have a derived field added grouping values by year-month. 

## Before
Only activity start date had the field, grouped by year-month. Other reports had derived fields grouped only by month and by year separately.

## After
Added this functionality so the field is added to the report automatically for every field of date type. Removed previous derived fields used on Contribution and Memberships reports that were built using only the month and only the year.

![image](https://user-images.githubusercontent.com/21999940/31249809-57a14d34-a9de-11e7-9a52-2aa37a65f141.png)
