### PR TITLE
GS-54: Prospect support

### DIFF
--- a/CRM/Activityreport/Entity.php
+++ b/CRM/Activityreport/Entity.php
@@ -3,15 +3,23 @@
 class CRM_Activityreport_Entity {
 
   /**
+   * Entities which may be supported by the extension.
+   *
+   * @var array
+   */
+  private static $entities = array(
+    'Activity' => TRUE,
+    'Contribution' => TRUE,
+    'Membership' => TRUE,
+    'Prospect' => 'uk.co.compucorp.civicrm.prospect',
+  );
+
+  /**
    * Entities supported by the extension.
    *
    * @var array
    */
-  private static $supportedEntities = array(
-    'Activity',
-    'Contribution',
-    'Membership',
-  );
+  private static $supportedEntities = array();
 
   /**
    * Entity name.
@@ -42,7 +50,7 @@ class CRM_Activityreport_Entity {
    * @return bool
    */
   private function isSupported() {
-    return in_array($this->entityName, self::$supportedEntities);
+    return in_array($this->entityName, self::getSupportedEntities());
   }
 
   /**
@@ -51,6 +59,25 @@ class CRM_Activityreport_Entity {
    * @return array
    */
   public static function getSupportedEntities() {
+    if (empty(self::$supportedEntities)) {
+      foreach (self::$entities as $key => $value) {
+        if ($value === TRUE) {
+          self::$supportedEntities[] = $key;
+        } else {
+          $isEnabled = CRM_Core_DAO::getFieldValue(
+            'CRM_Core_DAO_Extension',
+            $value,
+            'is_active',
+            'full_name'
+          );
+
+          if ($isEnabled) {
+            self::$supportedEntities[] = $key;
+          }
+        }
+      }
+    }
+
     return self::$supportedEntities;
   }
 

--- a/CRM/PivotCache/GroupProspect.php
+++ b/CRM/PivotCache/GroupProspect.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * @inheritdoc
+ */
+class CRM_PivotCache_GroupProspect extends CRM_PivotCache_AbstractGroup {
+
+  public function __construct($name = NULL) {
+    parent::__construct('Prospect');
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public function query($page, array $params) {
+    $cache = new CRM_Core_DAO_Cache();
+
+    $cache->group_name = $this->getName();
+
+    $cache->whereAdd("path <> 'header'");
+
+    $cache->orderBy('path ASC');
+
+    $cache->find();
+
+    return $cache;
+  }
+}

--- a/CRM/PivotReport/DataProspect.php
+++ b/CRM/PivotReport/DataProspect.php
@@ -125,13 +125,13 @@ class CRM_PivotReport_DataProspect extends CRM_PivotReport_AbstractData {
     foreach ($contacts as $contact) {
       if (!empty($contact['manager']) && (int) $contact['manager'] === 1) {
         return array(
-          'Case Manager Display Name' => $contact['display_name'],
+          ts('Case Manager Display Name') => $contact['display_name'],
         );
       }
     }
 
     return array(
-      'Case Manager Display Name' => '',
+      ts('Case Manager Display Name') => '',
     );
   }
 
@@ -245,17 +245,17 @@ class CRM_PivotReport_DataProspect extends CRM_PivotReport_AbstractData {
       }
 
       // Additional fields connected with Prospect data.
-      $fields['client']['id'] = 'Case Client ID';
-      $fields['client']['display_name'] = 'Case Client Display Name';
-      $fields['client']['contact_type'] = 'Case Client Type';
-      $fields['client']['contact_sub_type'] = 'Case Client Subtype';
+      $fields['client']['id'] = ts('Case Client ID');
+      $fields['client']['display_name'] = ts('Case Client Display Name');
+      $fields['client']['contact_type'] = ts('Case Client Type');
+      $fields['client']['contact_sub_type'] = ts('Case Client Subtype');
 
-      $fields['manager']['display_name'] = 'Case Manager Display Name';
+      $fields['manager']['display_name'] = ts('Case Manager Display Name');
 
-      $fields['pledge']['pledge_start_date'] = array('title' => 'Pledge Start Date', 'type' => CRM_Utils_Type::T_DATE);
-      $fields['pledge']['pledge_end_date'] = array('title' => 'Pledge End Date', 'type' => CRM_Utils_Type::T_DATE);
-      $fields['pledge']['pledge_total_paid'] = 'Pledge Total Paid';
-      $fields['pledge']['pledge_balance'] = 'Pledge Balance';
+      $fields['pledge']['pledge_start_date'] = array('title' => ts('Pledge Start Date'), 'type' => CRM_Utils_Type::T_DATE);
+      $fields['pledge']['pledge_end_date'] = array('title' => ts('Pledge End Date'), 'type' => CRM_Utils_Type::T_DATE);
+      $fields['pledge']['pledge_total_paid'] = ts('Pledge Total Paid');
+      $fields['pledge']['pledge_balance'] = ts('Pledge Balance');
 
       $includeFields = array(
         'contribution' => array(

--- a/CRM/PivotReport/DataProspect.php
+++ b/CRM/PivotReport/DataProspect.php
@@ -1,0 +1,233 @@
+<?php
+
+/**
+ * Provides a functionality to prepare Activity entity data for Pivot Table.
+ */
+class CRM_PivotReport_DataActivity extends CRM_PivotReport_AbstractData {
+
+  /**
+   * CRM_PivotReport_DataActivity constructor.
+   */
+  public function __construct() {
+    parent::__construct('Activity');
+
+    $this->additionalHeaderFields['Activity Date'] = null;
+    $this->additionalHeaderFields['Activity Expire Date'] = null;
+  }
+
+  /**
+   * @inheritdoc
+   */
+  protected function getEntityApiParams(array $inputParams) {
+    $params = array(
+      'sequential' => 1,
+      'is_current_revision' => 1,
+      'is_deleted' => 0,
+      'is_test' => 0,
+      'return' => implode(',', array_keys($this->getFields())),
+      'options' => array(
+        'sort' => 'activity_date_time ASC',
+        'limit' => self::ROWS_API_LIMIT,
+      ),
+    );
+
+    $startDate = !empty($inputParams['start_date']) ? $inputParams['start_date'] : NULL;
+    $endDate = !empty($inputParams['end_date']) ? $inputParams['end_date'] : NULL;
+
+    $activityDateFilter = $this->getAPIDateFilter($startDate, $endDate);
+    if (!empty($activityDateFilter)) {
+      $params['activity_date_time'] = $activityDateFilter;
+    }
+
+    return $params;
+  }
+
+  /**
+   * Returns an array containing API date filter conditions basing on specified
+   * dates.
+   *
+   * @param string $startDate
+   * @param string $endDate
+   *
+   * @return array|NULL
+   */
+  private function getAPIDateFilter($startDate, $endDate) {
+    $apiFilter = null;
+
+    if (!empty($startDate) && !empty($endDate)) {
+      $apiFilter = array('BETWEEN' => array($startDate, $endDate));
+    }
+    else if (!empty($startDate) && empty($endDate)) {
+      $apiFilter = array('>=' => $startDate);
+    }
+    else if (empty($startDate) && !empty($endDate)) {
+      $apiFilter = array('<=' => $endDate);
+    }
+
+    return $apiFilter;
+  }
+
+  /**
+   * @inheritdoc
+   */
+  protected function setCustomValue($key, $value) {
+    $result = $value;
+
+    switch ($key) {
+      case 'campaign_id':
+        if (!empty($value)) {
+          $campaign = civicrm_api3('Campaign', 'getsingle', array(
+            'sequential' => 1,
+            'return' => 'title',
+            'id' => $value,
+          ));
+          if ($campaign['is_error']) {
+            $result = '';
+          } else {
+            $result = $campaign['title'];
+          }
+        }
+      break;
+    }
+
+    $this->customizedValues[$key][$value] = $result;
+  }
+
+  /**
+   * @inheritdoc
+   */
+  protected function getEntityIndex(array $row) {
+    return substr($row['Activity Date Time'], 0, 10);
+  }
+
+  /**
+   * @inheritdoc
+   */
+  protected function getFields() {
+    if (empty($this->fields)) {
+      $unsetFields = array(
+        'is_current_revision',
+        'activity_is_deleted',
+        'weight',
+        'source_contact_id',
+        'phone_id',
+        'relationship_id',
+        'source_record_id',
+        'activity_is_test',
+        'is_test',
+        'parent_id',
+        'original_id',
+        'activity_details',
+      );
+      // Get standard Fields of Activity entity.
+      $fields = CRM_Activity_DAO_Activity::fields();
+
+      foreach ($unsetFields as $unsetField) {
+        unset($fields[$unsetField]);
+      }
+
+      if (!empty($fields['activity_type_id'])) {
+          $fields['activity_type_id']['title'] = ts('Activity Type');
+      }
+      if (!empty($fields['activity_date_time'])) {
+          $fields['activity_date_time']['title'] = ts('Activity Date Time');
+      }
+
+      $keys = CRM_Activity_DAO_Activity::fieldKeys();
+      $result = array();
+
+      // Now get Custom Fields of Activity entity.
+      $customFieldsResult = CRM_Core_DAO::executeQuery(
+        'SELECT g.id AS group_id, f.id AS id, f.label AS label, f.data_type AS data_type, ' .
+        'f.html_type AS html_type, f.date_format AS date_format, og.name AS option_group_name ' .
+        'FROM `civicrm_custom_group` g ' .
+        'LEFT JOIN `civicrm_custom_field` f ON f.custom_group_id = g.id ' .
+        'LEFT JOIN `civicrm_option_group` og ON og.id = f.option_group_id ' .
+        'WHERE g.extends = \'Activity\' AND g.is_active = 1 AND f.is_active = 1 AND f.html_type NOT IN (\'TextArea\', \'RichTextEditor\') AND (f.data_type <> \'String\' OR (f.data_type = \'String\' AND f.html_type <> \'Text\')) '
+      );
+
+      while ($customFieldsResult->fetch()) {
+        $customField = new CRM_Core_BAO_CustomField();
+        $customField->id = $customFieldsResult->id;
+        $customField->find(true);
+
+        $fields['custom_' . $customFieldsResult->id] = array(
+          'name' => 'custom_' . $customFieldsResult->id,
+          'title' => $customFieldsResult->label,
+          'pseudoconstant' => array(
+            'optionGroupName' => $customFieldsResult->option_group_name,
+          ),
+          'customField' => (array)$customField,
+        );
+      }
+
+      foreach ($fields as $key => $value) {
+        if (!empty($keys[$value['name']])) {
+          $key = $value['name'];
+        }
+        $result[$key] = $value;
+        $result[$key]['optionValues'] = $this->getOptionValues($value);
+      }
+
+      $this->fields = $result;
+    }
+
+    return $this->fields;
+  }
+
+  /**
+   * Returns available Option Values of specified $field array.
+   * If there is no available Option Values for the field, then return null.
+   *
+   * @param array $field
+   *   Field key
+   *
+   * @return array
+   */
+  private function getOptionValues($field) {
+    if (empty($field['pseudoconstant']['optionGroupName'])) {
+      return null;
+    }
+
+    $result = civicrm_api3('Activity', 'getoptions', array(
+      'field' => $field['name'],
+    ));
+
+    return $result['values'];
+  }
+
+  /**
+   * @inheritdoc
+   */
+  protected function getCount(array $params) {
+    $apiParams = array(
+      'is_current_revision' => 1,
+      'is_deleted' => 0,
+      'is_test' => 0,
+    );
+
+    $startDate = !empty($params['start_date']) ? $params['start_date'] : NULL;
+    $endDate = !empty($params['end_date']) ? $params['end_date'] : NULL;
+
+    $activityDateFilter = $this->getAPIDateFilter($startDate, $endDate);
+
+    if (!empty($activityDateFilter)) {
+      $apiParams['activity_date_time'] = $activityDateFilter;
+    }
+
+    return civicrm_api3('Activity', 'getcount', $apiParams);
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public function getDateFields() {
+    $result = parent::getDateFields();
+
+    $result[] = ts('Activity Date');
+    $result[] = ts('Activity Expire Date');
+
+    return $result;
+  }
+
+}

--- a/CRM/PivotReport/DataProspect.php
+++ b/CRM/PivotReport/DataProspect.php
@@ -1,18 +1,15 @@
 <?php
 
 /**
- * Provides a functionality to prepare Activity entity data for Pivot Table.
+ * Provides a functionality to prepare Prospect data for Pivot Table.
  */
-class CRM_PivotReport_DataActivity extends CRM_PivotReport_AbstractData {
+class CRM_PivotReport_DataProspect extends CRM_PivotReport_AbstractData {
 
   /**
-   * CRM_PivotReport_DataActivity constructor.
+   * CRM_PivotReport_DataProspect constructor.
    */
   public function __construct() {
-    parent::__construct('Activity');
-
-    $this->additionalHeaderFields['Activity Date'] = null;
-    $this->additionalHeaderFields['Activity Expire Date'] = null;
+    parent::__construct('Prospect', 'ProspectConverted');
   }
 
   /**
@@ -21,50 +18,152 @@ class CRM_PivotReport_DataActivity extends CRM_PivotReport_AbstractData {
   protected function getEntityApiParams(array $inputParams) {
     $params = array(
       'sequential' => 1,
-      'is_current_revision' => 1,
-      'is_deleted' => 0,
-      'is_test' => 0,
-      'return' => implode(',', array_keys($this->getFields())),
+      'api.Case.getsingle' => array('id' => '$value.prospect_case_id', 'api.Contact.get' => array('id' => array('IN' => '$value.client_id'), 'return' => array('id', 'contact_type', 'contact_sub_type', 'display_name'))),
+      'api.Contribution.get' => array('id' => '$value.payment_entity_id', 'return' => array('id', 'financial_type_id', 'contribution_status', 'total_amount', 'receive_date', 'receipt_date')),
+      'api.Pledge.get' => array('id' => '$value.payment_entity_id', 'return' => array('id', 'financial_type_id', 'status_id', 'pledge_amount', 'pledge_total_paid', 'pledge_create_date', 'pledge_start_date', 'pledge_end_date')),
       'options' => array(
-        'sort' => 'activity_date_time ASC',
+        'sort' => 'prospect_case_id ASC',
         'limit' => self::ROWS_API_LIMIT,
       ),
     );
-
-    $startDate = !empty($inputParams['start_date']) ? $inputParams['start_date'] : NULL;
-    $endDate = !empty($inputParams['end_date']) ? $inputParams['end_date'] : NULL;
-
-    $activityDateFilter = $this->getAPIDateFilter($startDate, $endDate);
-    if (!empty($activityDateFilter)) {
-      $params['activity_date_time'] = $activityDateFilter;
-    }
 
     return $params;
   }
 
   /**
-   * Returns an array containing API date filter conditions basing on specified
-   * dates.
-   *
-   * @param string $startDate
-   * @param string $endDate
-   *
-   * @return array|NULL
+   * @inheritdoc
    */
-  private function getAPIDateFilter($startDate, $endDate) {
-    $apiFilter = null;
+  protected function formatResult($data, $dataKey = null, $level = 0) {
+    $result = array();
+    $fields = $this->getFields();
 
-    if (!empty($startDate) && !empty($endDate)) {
-      $apiFilter = array('BETWEEN' => array($startDate, $endDate));
-    }
-    else if (!empty($startDate) && empty($endDate)) {
-      $apiFilter = array('>=' => $startDate);
-    }
-    else if (empty($startDate) && !empty($endDate)) {
-      $apiFilter = array('<=' => $endDate);
+    foreach ($data as $key => $prospect) {
+      $caseValues = $this->getCaseValues($prospect['api.Case.getsingle']);
+      $clientValues = $this->getRowValues($prospect['api.Case.getsingle']['api.Contact.get']['values'][0], 'client');
+      $managerValues = $this->getManager($prospect['api.Case.getsingle']['contacts']);
+
+      $paymentValues = array();
+      if ((int) $prospect['payment_type_id'] === CRM_Prospect_BAO_ProspectConverted::PAYMENT_TYPE_CONTRIBUTION) {
+        $paymentValues = $this->getRowValues($prospect['api.Contribution.get']['values'][0], 'contribution');
+      } else {
+        $paymentValues = $this->getRowValues($prospect['api.Pledge.get']['values'][0], 'pledge');
+        $paymentValues['Pledge Balance'] = CRM_Utils_Money::format((float) $paymentValues['pledge.pledge_amount'] - (float) $paymentValues[$fields['pledge.pledge_total_paid']], NULL, NULL, TRUE);
+      }
+
+      $row = array_merge($this->emptyRow, $this->additionalHeaderFields, $caseValues, $clientValues, $managerValues, $paymentValues);
+      $result[] = $this->formatRow($key, $row);
     }
 
-    return $apiFilter;
+    return $result;
+  }
+
+  /**
+   * Returns Prospect related Case fields and values.
+   *
+   * @param array $data
+   *
+   * @return array
+   */
+  protected function getCaseValues($data) {
+    $result = array();
+    $fields = $this->getFields();
+    $include = array('id', 'status_id', 'start_date', 'end_date');
+
+    foreach ($data as $key => $value) {
+      $resultKey = 'case.' . $key;
+      if (empty($fields[$resultKey])) {
+        continue;
+      }
+
+      if (in_array($key, $include) || CRM_Utils_String::startsWith($key, 'custom_')) {
+        $result[$resultKey] = $value;
+      }
+    }
+
+    return $result;
+  }
+
+  /**
+   * Returns Prospect related fields and values basing on specified entity name.
+   *
+   * @param array $data
+   * @param string $entityName
+   *
+   * @return array
+   */
+  protected function getRowValues($data, $entityName) {
+    $result = array();
+    $fields = $this->getFields();
+
+    foreach ($data as $key => $value) {
+      $fieldsKey = $entityName . '.' . $key;
+
+      if (empty($fields[$fieldsKey])) {
+        continue;
+      }
+
+      $resultKey = $fieldsKey;
+      if (!is_array($fields[$fieldsKey])) {
+        $resultKey = $fields[$fieldsKey];
+      }
+
+      $result[$resultKey] = $value;
+    }
+
+    return $result;
+  }
+
+  /**
+   * Returns an array containing manager label as key and manager display
+   * name as value.
+   *
+   * @param array $contacts
+   *
+   * @return array
+   */
+  protected function getManager($contacts) {
+    foreach ($contacts as $contact) {
+      if (!empty($contact['manager']) && (int) $contact['manager'] === 1) {
+        return array(
+          'Case Manager Display Name' => $contact['display_name'],
+        );
+      }
+    }
+
+    return array(
+      'Case Manager Display Name' => '',
+    );
+  }
+
+  /**
+   * Returns an array containing formatted rows of specified array.
+   *
+   * @param int $key
+   * @param array $row
+   *
+   * @return array
+   */
+  protected function formatRow($key, $row) {
+    $fields = $this->getFields();
+    $result = array();
+
+    foreach ($row as $key => $value) {
+      $label = $key;
+      if (!empty($fields[$key]['title'])) {
+        $label = $fields[$key]['title'];
+      }
+
+      $formattedValue = $this->formatValue($key, $value);
+      $result[$label] = $formattedValue;
+
+      if (is_array($formattedValue)) {
+        $this->multiValues[$key][] = $label;
+      }
+    }
+
+    ksort($result);
+
+    return $result;
   }
 
   /**
@@ -97,7 +196,7 @@ class CRM_PivotReport_DataActivity extends CRM_PivotReport_AbstractData {
    * @inheritdoc
    */
   protected function getEntityIndex(array $row) {
-    return substr($row['Activity Date Time'], 0, 10);
+    return NULL;
   }
 
   /**
@@ -105,35 +204,19 @@ class CRM_PivotReport_DataActivity extends CRM_PivotReport_AbstractData {
    */
   protected function getFields() {
     if (empty($this->fields)) {
-      $unsetFields = array(
-        'is_current_revision',
-        'activity_is_deleted',
-        'weight',
-        'source_contact_id',
-        'phone_id',
-        'relationship_id',
-        'source_record_id',
-        'activity_is_test',
-        'is_test',
-        'parent_id',
-        'original_id',
-        'activity_details',
-      );
-      // Get standard Fields of Activity entity.
-      $fields = CRM_Activity_DAO_Activity::fields();
+      $fields = array();
+      $keys = array();
+      $groups = array('case', 'client', 'manager', 'contribution', 'pledge');
 
-      foreach ($unsetFields as $unsetField) {
-        unset($fields[$unsetField]);
+      // Get standard Fields of Case entity.
+      $includeCaseFields = array('case_id', 'case_status_id', 'case_start_date', 'case_end_date');
+      $caseFields = CRM_Case_DAO_Case::fields();
+
+      foreach ($includeCaseFields as $includeField) {
+        $fields['case'][$includeField] = $caseFields[$includeField];
       }
 
-      if (!empty($fields['activity_type_id'])) {
-          $fields['activity_type_id']['title'] = ts('Activity Type');
-      }
-      if (!empty($fields['activity_date_time'])) {
-          $fields['activity_date_time']['title'] = ts('Activity Date Time');
-      }
-
-      $keys = CRM_Activity_DAO_Activity::fieldKeys();
+      $keys['case'] = CRM_Case_DAO_Case::fieldKeys();
       $result = array();
 
       // Now get Custom Fields of Activity entity.
@@ -143,7 +226,7 @@ class CRM_PivotReport_DataActivity extends CRM_PivotReport_AbstractData {
         'FROM `civicrm_custom_group` g ' .
         'LEFT JOIN `civicrm_custom_field` f ON f.custom_group_id = g.id ' .
         'LEFT JOIN `civicrm_option_group` og ON og.id = f.option_group_id ' .
-        'WHERE g.extends = \'Activity\' AND g.is_active = 1 AND f.is_active = 1 AND f.html_type NOT IN (\'TextArea\', \'RichTextEditor\') AND (f.data_type <> \'String\' OR (f.data_type = \'String\' AND f.html_type <> \'Text\')) '
+        'WHERE g.extends = \'Case\' AND g.is_active = 1 AND g.name IN (\'Prospect_Financial_Information\', \'Prospect_More_Information\', \'Prospect_Substatus\') AND f.is_active = 1 AND f.html_type NOT IN (\'TextArea\', \'RichTextEditor\') AND (f.data_type <> \'String\' OR (f.data_type = \'String\' AND f.html_type <> \'Text\')) '
       );
 
       while ($customFieldsResult->fetch()) {
@@ -151,7 +234,7 @@ class CRM_PivotReport_DataActivity extends CRM_PivotReport_AbstractData {
         $customField->id = $customFieldsResult->id;
         $customField->find(true);
 
-        $fields['custom_' . $customFieldsResult->id] = array(
+        $fields['case']['custom_' . $customFieldsResult->id] = array(
           'name' => 'custom_' . $customFieldsResult->id,
           'title' => $customFieldsResult->label,
           'pseudoconstant' => array(
@@ -161,12 +244,52 @@ class CRM_PivotReport_DataActivity extends CRM_PivotReport_AbstractData {
         );
       }
 
-      foreach ($fields as $key => $value) {
-        if (!empty($keys[$value['name']])) {
-          $key = $value['name'];
+      // Additional fields connected with Prospect data.
+      $fields['client']['id'] = 'Case Client ID';
+      $fields['client']['display_name'] = 'Case Client Display Name';
+      $fields['client']['contact_type'] = 'Case Client Type';
+      $fields['client']['contact_sub_type'] = 'Case Client Subtype';
+
+      $fields['manager']['display_name'] = 'Case Manager Display Name';
+
+      $fields['pledge']['pledge_start_date'] = array('title' => 'Pledge Start Date', 'type' => CRM_Utils_Type::T_DATE);
+      $fields['pledge']['pledge_end_date'] = array('title' => 'Pledge End Date', 'type' => CRM_Utils_Type::T_DATE);
+      $fields['pledge']['pledge_total_paid'] = 'Pledge Total Paid';
+      $fields['pledge']['pledge_balance'] = 'Pledge Balance';
+
+      $includeFields = array(
+        'contribution' => array(
+          'contribution_id', 'financial_type_id', 'total_amount', 'receive_date', 'receipt_date',
+        ),
+        'pledge' => array(
+          'pledge_id', 'pledge_financial_type_id', 'pledge_status_id', 'pledge_amount', 'pledge_create_date',
+        ),
+      );
+
+      // Include Contribution fields.
+      $contributionFields = CRM_Contribute_DAO_Contribution::fields();
+      foreach ($includeFields['contribution'] as $fieldKey) {
+        $fields['contribution'][$fieldKey] = $contributionFields[$fieldKey];
+      }
+      $fields['contribution']['contribution_status'] = 'Contribution Status';
+
+      // Include Pledge fields.
+      $pledgeFields = CRM_Pledge_DAO_Pledge::fields();
+      foreach ($includeFields['pledge'] as $fieldKey) {
+        $fields['pledge'][$fieldKey] = $pledgeFields[$fieldKey];
+      }
+
+      foreach ($groups as $group) {
+        foreach ($fields[$group] as $key => $value) {
+          if (!empty($keys[$group][$value['name']])) {
+            $key = $value['name'];
+          }
+          $result[$group . '.' . $key] = $value;
+
+          if (is_array($value)) {
+            $result[$group . '.' . $key]['optionValues'] = $this->getOptionValues($value);
+          }
         }
-        $result[$key] = $value;
-        $result[$key]['optionValues'] = $this->getOptionValues($value);
       }
 
       $this->fields = $result;
@@ -189,7 +312,7 @@ class CRM_PivotReport_DataActivity extends CRM_PivotReport_AbstractData {
       return null;
     }
 
-    $result = civicrm_api3('Activity', 'getoptions', array(
+    $result = civicrm_api3('Case', 'getoptions', array(
       'field' => $field['name'],
     ));
 
@@ -200,34 +323,6 @@ class CRM_PivotReport_DataActivity extends CRM_PivotReport_AbstractData {
    * @inheritdoc
    */
   protected function getCount(array $params) {
-    $apiParams = array(
-      'is_current_revision' => 1,
-      'is_deleted' => 0,
-      'is_test' => 0,
-    );
-
-    $startDate = !empty($params['start_date']) ? $params['start_date'] : NULL;
-    $endDate = !empty($params['end_date']) ? $params['end_date'] : NULL;
-
-    $activityDateFilter = $this->getAPIDateFilter($startDate, $endDate);
-
-    if (!empty($activityDateFilter)) {
-      $apiParams['activity_date_time'] = $activityDateFilter;
-    }
-
-    return civicrm_api3('Activity', 'getcount', $apiParams);
+    return civicrm_api3('ProspectConverted', 'getcount', array());
   }
-
-  /**
-   * @inheritdoc
-   */
-  public function getDateFields() {
-    $result = parent::getDateFields();
-
-    $result[] = ts('Activity Date');
-    $result[] = ts('Activity Expire Date');
-
-    return $result;
-  }
-
 }

--- a/CRM/PivotReport/DataProspect.php
+++ b/CRM/PivotReport/DataProspect.php
@@ -152,6 +152,7 @@ class CRM_PivotReport_DataProspect extends CRM_PivotReport_AbstractData {
       if (!empty($fields[$key]['title'])) {
         $label = $fields[$key]['title'];
       }
+      $label = ts($label);
 
       $formattedValue = $this->formatValue($key, $value);
       $result[$label] = $formattedValue;

--- a/templates/CRM/Activityreport/Page/ProspectReport.tpl
+++ b/templates/CRM/Activityreport/Page/ProspectReport.tpl
@@ -2,7 +2,7 @@
 <script type="text/javascript">
     CRM.$(function ($) {
       new CRM.PivotReport.PivotTable({
-        'entityName': 'Contribution',
+        'entityName': 'Prospect',
       });
     });
 </script>

--- a/templates/CRM/Activityreport/Page/ProspectReport.tpl
+++ b/templates/CRM/Activityreport/Page/ProspectReport.tpl
@@ -1,0 +1,9 @@
+{literal}
+<script type="text/javascript">
+    CRM.$(function ($) {
+      new CRM.PivotReport.PivotTable({
+        'entityName': 'Contribution',
+      });
+    });
+</script>
+{/literal}

--- a/templates/CRM/Activityreport/Page/ReportSelector.tpl
+++ b/templates/CRM/Activityreport/Page/ReportSelector.tpl
@@ -2,23 +2,7 @@
 <script type="text/javascript">
   CRM.$(function ($) {
     CRM.$('#reportSelectorBtn').on( "click", function() {
-
-      var url = '';
-
-      switch (CRM.$('#CRMData').val()) {
-        case 'Activity':
-          url = CRM.url('civicrm/activity-report', {});
-          break;
-
-        case 'Contribution':
-          url = CRM.url('civicrm/contribution-report', {});
-          break;
-
-        case 'Membership':
-          url = CRM.url('civicrm/membership-report', {});
-          break;
-      }
-
+      var url = CRM.url('civicrm/' + CRM.$('#CRMData').val().toLocaleLowerCase() + '-report', {});
       window.location.href = url;
     });
   });

--- a/xml/Menu/activityreport.xml
+++ b/xml/Menu/activityreport.xml
@@ -18,4 +18,10 @@
     <page_arguments>entity=Membership</page_arguments>
     <access_arguments>access CiviCRM pivot table reports</access_arguments>
   </item>
+  <item>
+    <path>civicrm/prospect-report</path>
+    <page_callback>CRM_Activityreport_Page_PivotReport</page_callback>
+    <page_arguments>entity=Prospect</page_arguments>
+    <access_arguments>access CiviCRM pivot table reports</access_arguments>
+  </item>
 </menu>


### PR DESCRIPTION
- Implementing Prospect extension's support (if the extension is installed and enabled).
- Adding Prospect data into caching.

Sample Prospect report view:
![gs-54-prospect](https://user-images.githubusercontent.com/8986209/31495203-fb41b960-af56-11e7-8e15-2ee62e68f5af.png)

Prospect report fields are susceptible to word replacement (during cache building).
![gs-54-word-replacement-list](https://user-images.githubusercontent.com/8986209/31497435-62d6935e-af5f-11e7-8ce8-c64c5a3b5c89.png)

![gs-54-prospect-word-replaced](https://user-images.githubusercontent.com/8986209/31497440-668d1cac-af5f-11e7-9466-03b4fff12ae6.png)
