### PR TITLE
GS-68:  Remove Activity Date Filter

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -78,6 +78,6 @@ select.relativeFilter {
   vertical-align: middle;
 }
 
-#pivot-report-config .hidden {
+#pivot-report-config .hidden, #pivot-report-filters {
   display: none;
 }

--- a/js/PivotReport.PivotTable.js
+++ b/js/PivotReport.PivotTable.js
@@ -235,7 +235,7 @@ CRM.PivotReport.PivotTable = (function($) {
       that.dateFields = result.dateFields.values;
       that.relativeFilters = result.relativeFilters.values;
       that.header = result.getHeader.values;
-      that.total = parseInt(result.getCount.result, 10);
+      that.total = parseInt(result.getCount, 10);
       that.crmConfig = result.getConfig.values[0];
 
       $.each(that.dateFields, function (i, value) {
@@ -246,6 +246,7 @@ CRM.PivotReport.PivotTable = (function($) {
         CRM.alert(that.config.initialLoad.message, '', 'info');
 
         $('input[type="button"].load-all-data-button', this.pivotReportForm).removeClass('hidden');
+        $('#pivot-report-filters').show();
         var filter = that.config.initialLoad.getFilter();
 
         that.loadDataByFilter(filter.getFrom(), filter.getTo());
@@ -370,7 +371,7 @@ CRM.PivotReport.PivotTable = (function($) {
       if (!totalFiltered) {
         $('#pivot-report-preloader').addClass('hidden');
 
-        if (this.config.filter) {
+        if (that.config.filter) {
           $('#pivot-report-filters').removeClass('hidden');
         }
 
@@ -447,6 +448,7 @@ CRM.PivotReport.PivotTable = (function($) {
         cols: [],
         aggregatorName: "Count",
         unusedAttrsVertical: false,
+        menuLimit: 5000,
         rendererOptions: {
             c3: {
                 size: {

--- a/templates/CRM/Activityreport/Page/ActivityReport.tpl
+++ b/templates/CRM/Activityreport/Page/ActivityReport.tpl
@@ -7,9 +7,9 @@
         Use this form to change the date range for which data needs to be
         visualized.
       </p>
-      <label for="keyvalue_from">Activity start date</label>
+      <label for="keyvalue_from">Load Activities From:</label>
       <input type="text" name="keyvalue_from" value="">
-      <label for="keyvalue_to">Activity end date</label>
+      <label for="keyvalue_to">To:</label>
       <input type="text" name="keyvalue_to" value="">
       <input class="apply-filters-button" type="button" value="Apply filters">
       <input class="load-all-data-button hidden" type="button" value="Load all data">

--- a/templates/CRM/Activityreport/Page/ActivityReport.tpl
+++ b/templates/CRM/Activityreport/Page/ActivityReport.tpl
@@ -1,11 +1,19 @@
 <div id="pivot-report-filters" class="hidden">
   <form>
-    <label for="keyvalue_from">Activity start date</label>
-    <input type="text" name="keyvalue_from" value="">
-    <label for="keyvalue_to">Activity end date</label>
-    <input type="text" name="keyvalue_to" value="">
-    <input class="apply-filters-button" type="button" value="Apply filters">
-    <input class="load-all-data-button hidden" type="button" value="Load all data">
+    <fieldset>
+      <legend>Working Dataset Filter</legend>
+      <p>
+        The total number of activities exceeds 50,000. Only last 30 days loaded.
+        Use this form to change the date range for which data needs to be
+        visualized.
+      </p>
+      <label for="keyvalue_from">Activity start date</label>
+      <input type="text" name="keyvalue_from" value="">
+      <label for="keyvalue_to">Activity end date</label>
+      <input type="text" name="keyvalue_to" value="">
+      <input class="apply-filters-button" type="button" value="Apply filters">
+      <input class="load-all-data-button hidden" type="button" value="Load all data">
+    </fieldset>
   </form>
 </div>
 
@@ -15,9 +23,10 @@
       new CRM.PivotReport.PivotTable({
         'entityName': 'Activity',
         'filter': true,
+        'filterField': 'Activity Date',
         'initialLoad': {
-          'limit': 5000,
-          'message': 'There are more than 5000 items, getting only items from last 30 days.',
+          'limit': 50000,
+          'message': 'There are more than 50000 items, getting only items from last 30 days.',
           'getFilter': function() {
             var startDateFilterValue = new Date();
             var endDateFilterValue = new Date();


### PR DESCRIPTION
## Overview
The original idea was to remove the extra activity date filters on the page, as it is now possible to use 'from' and 'to' filters on each date field. However, the activities' main filter was conceived to limit the number of records loaded from the back-end into the pivot report, which is something that would be difficult to implement, and awkward UX-wise to use within in-field date filters. Thus, now the date filter only appears if the number of activities exceeds 50K.

## Before
The Dates filter appearing before the pivot table report appeared to be redundant, as you could also use the filters within date fields to filter results.

![image](https://user-images.githubusercontent.com/21999940/31556950-9ad9c0f2-b00c-11e7-9c63-e5d598f504d5.png)

## After
The dates field only appears if there are more than 50,000 activites in the database, explicitly explaining the use of this filter is to change the dataset used to build the pivot report.

![image](https://user-images.githubusercontent.com/21999940/31556850-450cfdba-b00c-11e7-960b-bfac28f108df.png)

## Technical Notes
Performance tests were run for 10K, 20K, 50K, 100K and 120K activities, by populating the database with random activities spanning the last 10 years. In all cases, the report remained usable, even though by the time it got to 120K, initial loading of the report took over 1:30 min. After loading, performance differences were negligible.

Problems were found however on building the cache for over 50K activities, due to php maximum memory usage. For 20K, memory usage was just above 256M, which is the default limit set for drush commands. To generate the whole 120K, memory usage got to above 1GB. This is something we may need to address in the future.

### Test Results
#### 50K: 
- 7m 5s to build cache
- 617.25MB used memory
- 47s to load page and render report
- 6s to process relative date
- 2s to apply changes to report.
#### 100K: 
- 16 min 3s to build cache 
- 1184MB memory used 
- 1.5 min to load page and render report 
- 7s to process relative date filter
- 4s to apply changes to report
#### 120K: 
- 20 min 59s to build cache
- 1428MB memory used
- 1.7 min to load page and render report
- 23s to process relative date filter
- 7s to apply changes to report.
