### PR TITLE
GS-71: Make Date Selection Widgets Disappear on Relative Dates

### DIFF
--- a/js/PivotReport.Dates.js
+++ b/js/PivotReport.Dates.js
@@ -7,8 +7,8 @@ CRM.PivotReport.Dates = (function($) {
    *
    * @constructor
    */
-  function Dates() {
-
+  function Dates(config) {
+    this.crmConfig = config;
   };
 
   /**

--- a/js/PivotReport.PivotTable.js
+++ b/js/PivotReport.PivotTable.js
@@ -62,7 +62,7 @@ CRM.PivotReport.PivotTable = (function($) {
 
           if ($.inArray($(this).text().replace(/[()0-9]/g, ''), that.dateFields) >= 0) {
             $(this).after('' +
-              '<div class="inner_date_filters">' +
+              '<div id="inner_' + fieldName + '" class="inner_date_filters">' +
               ' <form>' +
               '   <input type="text" id="fld_' + fieldName + '_start" name="fld_' + fieldName + '_start" class="inner_date fld_' + fieldName + '_start" value=""> - ' +
               '   <input type="text" id="fld_' + fieldName + '_end" name="fld_' + fieldName + '_end" class="inner_date fld_' + fieldName + '_end" value="">' +
@@ -113,7 +113,7 @@ CRM.PivotReport.PivotTable = (function($) {
         $('input.' + fieldInfo[1]).each(function () {
           var checkDateValue = $('span.value', $(this).parent()).text();
           var checked = false;
-          var dateChecker = new CRM.PivotReport.Dates();
+          var dateChecker = new CRM.PivotReport.Dates(that.crmConfig);
 
           if (dateChecker.dateInRange(checkDateValue, startDateValue, endDateValue)) {
             checked = true;
@@ -146,7 +146,7 @@ CRM.PivotReport.PivotTable = (function($) {
     var unit = relativeDateInfo[1];
     var relativeTerm = relativeDateInfo[0];
 
-    var dateCalculator = new CRM.PivotReport.Dates();
+    var dateCalculator = new CRM.PivotReport.Dates(this.crmConfig);
     var dates = dateCalculator.getRelativeStartAndEndDates(relativeTerm, unit);
 
     var fieldInfo = select.attr('name').split('_');
@@ -157,6 +157,12 @@ CRM.PivotReport.PivotTable = (function($) {
 
     $('#fld_' + fieldName + '_end').val(CRM.utils.formatDate(dates.endDate, CRM.config.dateInputFormat)).change();
     $('input.inner_date.fld_' + fieldName + '_end.hasDatepicker').val(CRM.utils.formatDate(dates.endDate, CRM.config.dateInputFormat));
+
+    if (select.val() !== '') {
+      $('#inner_' + fieldName).hide();
+    } else {
+      $('#inner_' + fieldName).show();
+    }
   };
 
   /**


### PR DESCRIPTION
## Overview
Relative dates filter was not working as expected. This should work as per relative dates filter in Find Activities. (ie; only when you select 'choose date range' option the date widget should show up).

## Before
Controls to select dates were visible even if a relative date was selected.

![image](https://user-images.githubusercontent.com/21999940/31558896-52be9d3a-b014-11e7-8406-5628474c65f9.png)

## After
Controls disappear when a relative date is selected.

![image](https://user-images.githubusercontent.com/21999940/31558864-2df175a4-b014-11e7-9e8c-bbd8c2c36305.png)
