### PR TITLE
GS-71: Fix Issues With Relative Dates Filters

### DIFF
--- a/js/PivotReport.PivotTable.js
+++ b/js/PivotReport.PivotTable.js
@@ -124,6 +124,13 @@ CRM.PivotReport.PivotTable = (function($) {
           } else if (checked == false && $(this).is(':checked')) {
             $(this).click();
           }
+
+          if (checked === true) {
+            $(this).parent().parent().show();
+          } else {
+            $(this).parent().parent().hide();
+          }
+
         });
       });
 
@@ -142,27 +149,37 @@ CRM.PivotReport.PivotTable = (function($) {
    *   value.
    */
   PivotTable.prototype.changeFilterDates = function (select) {
-    var relativeDateInfo = select.val().split('.');
-    var unit = relativeDateInfo[1];
-    var relativeTerm = relativeDateInfo[0];
-
-    var dateCalculator = new CRM.PivotReport.Dates(this.crmConfig);
-    var dates = dateCalculator.getRelativeStartAndEndDates(relativeTerm, unit);
-
     var fieldInfo = select.attr('name').split('_');
     var fieldName = fieldInfo[1];
 
-    $('#fld_' + fieldName + '_start').val(CRM.utils.formatDate(dates.startDate, CRM.config.dateInputFormat)).change();
-    $('input.inner_date.fld_' + fieldName + '_start.hasDatepicker').val(CRM.utils.formatDate(dates.startDate, CRM.config.dateInputFormat));
-
-    $('#fld_' + fieldName + '_end').val(CRM.utils.formatDate(dates.endDate, CRM.config.dateInputFormat)).change();
-    $('input.inner_date.fld_' + fieldName + '_end.hasDatepicker').val(CRM.utils.formatDate(dates.endDate, CRM.config.dateInputFormat));
+    var startValue = '';
+    var endValue = '';
+    var displayStart = '';
+    var displayEnd = '';
 
     if (select.val() !== '') {
+      var relativeDateInfo = select.val().split('.');
+      var unit = relativeDateInfo[1];
+      var relativeTerm = relativeDateInfo[0];
+
+      var dateCalculator = new CRM.PivotReport.Dates(this.crmConfig);
+      var dates = dateCalculator.getRelativeStartAndEndDates(relativeTerm, unit);
+
+      startValue = dates.startDate.toUTCString();
+      endValue = dates.endDate.toUTCString();
+      displayStart = CRM.utils.formatDate(dates.startDate, CRM.config.dateInputFormat);
+      displayEnd = CRM.utils.formatDate(dates.endDate, CRM.config.dateInputFormat);
+
       $('#inner_' + fieldName).hide();
     } else {
       $('#inner_' + fieldName).show();
     }
+
+    $('input.inner_date.fld_' + fieldName + '_start.hasDatepicker').val(displayStart);
+    $('input.inner_date.fld_' + fieldName + '_end.hasDatepicker').val(displayEnd);
+    $('#fld_' + fieldName + '_start').val(startValue);
+    $('#fld_' + fieldName + '_end').val(endValue);
+    $('#fld_' + fieldName + '_end').change();
   };
 
   /**


### PR DESCRIPTION
## Overview
Several problems were found when testing the relative date control on the pivot report. On one hand, when options like 'today' or 'this week' were selected, the filtering did not happen and there were no results. On the other, when a date range is set, the record list should only show those which are within the date range. Currently, it ticks the ones which are within the date range, but the other dates outside the range are still shown. It should only tick and show the ones within the date range.

## Before
Filtering of some relative dates was failing because hours of start and end were not being taken into account. Thus, for fields that were of both date and time, filters failed, as the time taken for both start and end dates was 00:00.

On the other hand, the specification of the relative dates control required only dates within the selected range to be shown, however, this was not implemented, merely unchecking dates out of the range. 

![before](https://user-images.githubusercontent.com/21999940/31799941-f635e0ca-b502-11e7-8d2c-39d926d20e5e.gif)

## After
Included start and end times in relative filter.
Implemented the required behaviour by adding .hide() and .show() calls were appropriate.

![after](https://user-images.githubusercontent.com/21999940/31799950-ff8ae738-b502-11e7-9959-48764308faf2.gif)
