### PR TITLE
GS-81: CSV and TSV reports issue

### DIFF
--- a/packages/pivottable-cc/export_renderers.js
+++ b/packages/pivottable-cc/export_renderers.js
@@ -54,8 +54,7 @@
         row.push(aggregatorName);
       } else {
         for (i = 0; i < colKeys.length; i++) {
-          colKey = colKeys[j];
-          row.push(colKey.join("-"));
+          row.push(colKeys[i]);
         }
       }
 


### PR DESCRIPTION
There was a bug in export_renderers.js script (referencing undefined index variable) which only appear when rendering TSV / CSV export with one or more columns.

Before fixing:
![gs-81-before](https://user-images.githubusercontent.com/8986209/31888895-18aaaeee-b7fe-11e7-8bac-02732cbfafce.png)

After fixing:
![gs-81-after](https://user-images.githubusercontent.com/8986209/31888902-1d65c162-b7fe-11e7-9714-88980eec33e2.png)
