### PR TITLE
GS-76: Exclude Deleted Cases From Report

### DIFF
--- a/CRM/PivotData/AbstractData.php
+++ b/CRM/PivotData/AbstractData.php
@@ -630,7 +630,7 @@ abstract class CRM_PivotData_AbstractData implements CRM_PivotData_DataInterface
 
     foreach ($fields as $key => $value) {
       if (!CRM_Utils_Array::value('api_call', $value, false)) {
-        if (!is_array($value)) {
+        if (!is_array($value) && !empty($value)) {
           $key = $value;
         } elseif (!empty($value['title'])) {
           $key = $value['title'];

--- a/CRM/PivotData/DataCase.php
+++ b/CRM/PivotData/DataCase.php
@@ -18,8 +18,8 @@ class CRM_PivotData_DataCase extends CRM_PivotData_AbstractData {
   protected function getEntityApiParams(array $inputParams) {
     $params = array(
       'sequential' => 1,
-      'api.Contact.get' => array('id' => array('IN' => '$value.client_id'), 'return' => array('id', 'contact_type', 'contact_sub_type', 'display_name')),
-      'return' => array_merge($this->getCaseFields(), array('contacts')),
+      'api.Contact.get' => array('id' => '$value.client_id', 'return' => array('id', 'contact_type', 'contact_sub_type', 'display_name')),
+      'return' => array_merge($this->getCaseFields(), array('contacts', 'contact_id')),
       'options' => array(
         'sort' => 'start_date ASC',
         'limit' => self::ROWS_API_LIMIT,
@@ -192,7 +192,9 @@ class CRM_PivotData_DataCase extends CRM_PivotData_AbstractData {
       $caseFields = CRM_Case_DAO_Case::fields();
 
       foreach ($includeCaseFields as $includeField) {
-        $fields['case'][$includeField] = $caseFields[$includeField];
+        if (isset($caseFields[$includeField])) {
+          $fields['case'][$includeField] = $caseFields[$includeField];
+        }
       }
 
       $keys['case'] = CRM_Case_DAO_Case::fieldKeys();

--- a/CRM/PivotData/DataCase.php
+++ b/CRM/PivotData/DataCase.php
@@ -18,6 +18,7 @@ class CRM_PivotData_DataCase extends CRM_PivotData_AbstractData {
   protected function getEntityApiParams(array $inputParams) {
     $params = array(
       'sequential' => 1,
+      'is_deleted' => 0,
       'api.Contact.get' => array('id' => '$value.client_id', 'return' => array('id', 'contact_type', 'contact_sub_type', 'display_name')),
       'return' => array_merge($this->getCaseFields(), array('contacts', 'contact_id')),
       'options' => array(
@@ -256,6 +257,8 @@ class CRM_PivotData_DataCase extends CRM_PivotData_AbstractData {
    * @inheritdoc
    */
   protected function getCount(array $params) {
-    return civicrm_api3('Case', 'getcount', array());
+    return civicrm_api3('Case', 'getcount', array(
+      'is_deleted' => 0
+    ));
   }
 }

--- a/CRM/PivotData/DataProspect.php
+++ b/CRM/PivotData/DataProspect.php
@@ -18,9 +18,9 @@ class CRM_PivotData_DataProspect extends CRM_PivotData_DataCase {
   protected function getEntityApiParams(array $inputParams) {
     $params = array(
       'sequential' => 1,
-      'api.Contact.get' => array('id' => array('IN' => '$value.client_id'), 'return' => array('id', 'contact_type', 'contact_sub_type', 'display_name')),
+      'api.Contact.get' => array('id' => '$value.client_id', 'return' => array('id', 'contact_type', 'contact_sub_type', 'display_name')),
       'api.ProspectConverted.get' => array('prospect_case_id' => '$value.id'),
-      'return' => array_merge($this->getCaseFields(), array('contacts')),
+      'return' => array_merge($this->getCaseFields(), array('contacts', 'contct_id')),
       'options' => array(
         'sort' => 'id ASC',
         'limit' => self::ROWS_API_LIMIT,

--- a/CRM/PivotData/DataProspect.php
+++ b/CRM/PivotData/DataProspect.php
@@ -18,9 +18,10 @@ class CRM_PivotData_DataProspect extends CRM_PivotData_DataCase {
   protected function getEntityApiParams(array $inputParams) {
     $params = array(
       'sequential' => 1,
+      'is_deleted' => 0,
       'api.Contact.get' => array('id' => '$value.client_id', 'return' => array('id', 'contact_type', 'contact_sub_type', 'display_name')),
       'api.ProspectConverted.get' => array('prospect_case_id' => '$value.id'),
-      'return' => array_merge($this->getCaseFields(), array('contacts', 'contct_id')),
+      'return' => array_merge($this->getCaseFields(), array('contacts', 'contact_id')),
       'options' => array(
         'sort' => 'id ASC',
         'limit' => self::ROWS_API_LIMIT,

--- a/js/PivotReport.PivotTable.js
+++ b/js/PivotReport.PivotTable.js
@@ -58,9 +58,9 @@ CRM.PivotReport.PivotTable = (function($) {
       $(this).children().each(function () {
 
         if ($(this).prop("tagName") == 'H4') {
-          fieldName = $(this).text().replace(/[ ()0-9]/g, '');
+          fieldName = $(this).text().replace(/[ ()0-9?]/g, '');
 
-          if ($.inArray($(this).text().replace(/[()0-9]/g, ''), that.dateFields) >= 0) {
+          if ($.inArray($(this).text().replace(/[()0-9?]/g, ''), that.dateFields) >= 0) {
             $(this).after('' +
               '<div id="inner_' + fieldName + '" class="inner_date_filters">' +
               ' <form>' +


### PR DESCRIPTION
## Overview
Deleted entity data should not be listed in the report. This was not happening for Case and prospects entities.

## Before
Deleted cases were included in the pivot report. Also, cache rebuilding process was failing with fatal error, as client_id was not being resolved correctly to the contact_id, since for the field client_id to be returned, contact_id must be part of return fields.

## After
Deleted cases are no longer in either Case or Prospect. Added contact_id to return fields. Changed 'IN' operator on chained API call to contact for '=' operator, since 'IN' is unsupported for CiviCRM version <= v4.7.18.