### PR TITLE
GS-83: Fix Source of Multiple PHP Notices on Cache Rebuild

### DIFF
--- a/CRM/PivotData/AbstractData.php
+++ b/CRM/PivotData/AbstractData.php
@@ -524,20 +524,8 @@ abstract class CRM_PivotData_AbstractData implements CRM_PivotData_DataInterface
 
         $result[$key] = $this->formatResult($value, $dataKey, $level + 1);
 
-        if ($level === 1 && is_array($result[$key]) && !$fields[$key]['api_call']) {
+        if ($level === 1 && is_array($result[$key])) {
           $this->multiValues[$baseKey][] = $key;
-        }
-
-        if (CRM_Utils_Array::value('api_call', $fields[$key], false)) {
-          foreach ($result[$key] as $apiKey => $apiValue) {
-            if (!empty($fields[$apiKey]['title'])) {
-              $apiKey = $fields[$apiKey]['title'];
-            }
-
-            $result[$apiKey] = $apiValue;
-          }
-
-          unset($result[$key]);
         }
       }
 
@@ -578,20 +566,11 @@ abstract class CRM_PivotData_AbstractData implements CRM_PivotData_DataInterface
 
     $fields = $this->getFields();
     $dataType = !empty($fields[$key]['customField']['data_type']) ? $fields[$key]['customField']['data_type'] : null;
-    $isAPICall = CRM_Utils_Array::value('api_call', $fields[$key], false);
 
-    if (is_array($value) && $dataType !== 'File' && !$isAPICall) {
+    if (is_array($value) && $dataType !== 'File') {
       $valueArray = array();
       foreach ($value as $valueKey => $valueItem) {
         $valueArray[] = $this->formatValue($key, $valueKey, $level + 1);
-      }
-      return $valueArray;
-    }
-
-    if ($isAPICall && is_array($value)) {
-      $valueArray = array();
-      foreach ($value as $valueKey => $valueItem) {
-        $valueArray[$valueKey] = $this->formatValue($valueKey, $valueItem, $level + 1);
       }
       return $valueArray;
     }
@@ -691,15 +670,13 @@ abstract class CRM_PivotData_AbstractData implements CRM_PivotData_DataInterface
     $fields = $this->getFields();
 
     foreach ($fields as $key => $value) {
-      if (!CRM_Utils_Array::value('api_call', $value, false)) {
-        if (!is_array($value) && !empty($value)) {
-          $key = $value;
-        } elseif (!empty($value['title'])) {
-          $key = $value['title'];
-        }
-
-        $result[$key] = '';
+      if (!is_array($value) && !empty($value)) {
+        $key = $value;
+      } elseif (!empty($value['title'])) {
+        $key = $value['title'];
       }
+
+      $result[$key] = '';
     }
 
     ksort($result);


### PR DESCRIPTION
## Overview
Rebuilding report caches through the front end caused a large amount of PHP notices to be logged to watchdog, affecting negatively the performance of the process.

```
INSERT INTO watchdog (uid, type, message, variables, severity, link, location, referer, hostname, timestamp) VALUES ('1', 'php', '%type: !message in %function (line %line of %file).', 'a:6:
{s:5:\"%type\";s:6:\"Notice\";s:8:\"!message\";s:32:\"Undefined index: Activity Status\";s:9:\"%function\";s:42:\"CRM_PivotData_AbstractData->formatResult()\";s:5:\"%file\";s:144:\"/var/www/greenhouse-data.ccuptest.co.uk/httpdocs/sites/all/civicrm_extensions/uk.co.compucorp.civicrm.pivotreport/CRM/PivotData/AbstractData.php\";s:5:\"%line\";i:531;s:14:\"severity_level\";i:5;}
', '5', '', 'https://greenhouse-data.ccuptest.co.uk/civicrm/ajax/rest', 'https://greenhouse-data.ccuptest.co.uk/civicrm/activity-report', '185.53.227.161', '1508773159')
```

## Before
Rebuilding the cache from front-end caused several PHP notice messages to be logged to watchdog, since an array was trying to be accessed with keys it did not have. This array in particular was being used this way for every field in every record for every entity, resulting in the problem escalating out of control on large datasets.

## After
This part of the code was obsolete, so the problem was fixed by deleting the offending code.