### PR TITLE
GS-86: Handle Cases With Multiple Clients

### DIFF
--- a/CRM/PivotData/DataCase.php
+++ b/CRM/PivotData/DataCase.php
@@ -52,7 +52,7 @@ class CRM_PivotData_DataCase extends CRM_PivotData_AbstractData {
 
     foreach ($data as $key => $case) {
       $caseValues = $this->getCaseValues($case);
-      $clientValues = $this->getRowValues($case['api.Contact.get']['values'][0], 'client');
+      $clientValues = $this->getClients($case['api.Contact.get']['values']);
       $managerValues = $this->getManager($case['contacts']);
 
       $row = array_merge($this->emptyRow, $this->additionalHeaderFields, $caseValues, $clientValues, $managerValues);
@@ -60,6 +60,24 @@ class CRM_PivotData_DataCase extends CRM_PivotData_AbstractData {
     }
 
     return $result;
+  }
+
+  private function getClients($clients) {
+    $clientFields = array();
+
+    foreach ($clients as $currentClient) {
+      $rowValues = $this->getRowValues($currentClient, 'client');
+
+      foreach ($rowValues as $field => $value){
+        $clientFields[$field][$value] = $value;
+      }
+    }
+
+    foreach ($clientFields as $field => $values) {
+      $clientFields[$field] = implode(', ', $values);
+    }
+
+    return $clientFields;
   }
 
   /**


### PR DESCRIPTION
## Overview
"Case Client Display Name" always shows up the same contact in the case and prospect reports, for all cases/prospects. Also, it should show all case clients when there are multiple case clients.

## Before
CiviCase can be configured to have more than one client per case, but the pivot report was only showing data for the first client found.

![image](https://user-images.githubusercontent.com/21999940/32012850-e7535120-b97e-11e7-8c4f-101d1775bad9.png)

## After
 Processed all client data into the report by concatenating and deduping each field's values.

![image](https://user-images.githubusercontent.com/21999940/32012634-1ddae880-b97e-11e7-912c-1367859049b3.png)
