### PR TITLE
GS-86: Fix Subtypes on Cases and Prospect Reports

### DIFF
--- a/CRM/PivotData/DataCase.php
+++ b/CRM/PivotData/DataCase.php
@@ -62,13 +62,25 @@ class CRM_PivotData_DataCase extends CRM_PivotData_AbstractData {
     return $result;
   }
 
-  private function getClients($clients) {
+  /**
+   * Builds an array with client's data impleded for each field, to handle cases
+   * with multiple clients.
+   *
+   * @param array $clients
+   *   Array with client's data.
+   *
+   * @return array
+   */
+  protected function getClients($clients) {
     $clientFields = array();
 
     foreach ($clients as $currentClient) {
       $rowValues = $this->getRowValues($currentClient, 'client');
 
       foreach ($rowValues as $field => $value){
+        if (is_array($value)) {
+          $value = implode(', ', $value);
+        }
         $clientFields[$field][$value] = $value;
       }
     }

--- a/CRM/PivotData/DataProspect.php
+++ b/CRM/PivotData/DataProspect.php
@@ -40,7 +40,7 @@ class CRM_PivotData_DataProspect extends CRM_PivotData_DataCase {
 
     foreach ($data as $key => $inputRow) {
       $caseValues = $this->getCaseValues($inputRow);
-      $clientValues = $this->getRowValues($inputRow['api.Contact.get']['values'][0], 'client');
+      $clientValues = $this->getClients($inputRow['api.Contact.get']['values']);
       $managerValues = $this->getManager($inputRow['contacts']);
 
       $paymentValues = array();


### PR DESCRIPTION
## Overview
Multiple case clients were showing up on Cases Report, but client subtypes were not. 
Also, all this (multiple case clients, case client subtype) should work in Prospect reports as well.

## Before
A contact can have many subtypes, which is why they weren't being shown, as
the result was an array and was being used as a string.

## After
Implemented treatment of array values for clients by imploding into a comma
separated string.