### PR TITLE
GS-88: Add Menu Items per Enabled Entity

### DIFF
--- a/pivotreport.php
+++ b/pivotreport.php
@@ -165,6 +165,9 @@ function pivotreport_civicrm_permission(&$permissions) {
 
 /**
  * Implements hook_civicrm_entityTypes().
+ *
+ * @param array $entityTypes
+ *   List of entity types
  */
 function pivotreport_civicrm_entityTypes(&$entityTypes) {
   $entityTypes[] = [
@@ -172,4 +175,38 @@ function pivotreport_civicrm_entityTypes(&$entityTypes) {
     'class' => 'CRM_PivotReport_DAO_PivotReportConfig',
     'table' => 'civicrm_pivotreport_config',
   ];
+}
+
+/**
+ * Implements hook_civicrm_navigationMenu()
+ *
+ * @param array $params
+ *   List of menu items
+ */
+function pivotreport_civicrm_navigationMenu(&$params) {
+  $entities = CRM_PivotReport_Entity::getSupportedEntities();
+
+  $reportID = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Navigation', 'Reports', 'id', 'name');
+  $pivotID = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Navigation', 'pivotreport', 'id', 'name');
+  $navId = CRM_Core_DAO::singleValueQuery("SELECT max(id) FROM civicrm_navigation");
+
+  $params[$reportID]['child'][$pivotID]['attributes']['url'] = null;
+
+  $weight = 0;
+  foreach ($entities as $currentItem) {
+    $navId++;
+
+    $params[$reportID]['child'][$pivotID]['child'][$navId] = array(
+      'attributes' => array (
+        'label' => ts($currentItem),
+        'name' => strtolower($currentItem) . '-report',
+        'url' => 'civicrm/' . strtolower($currentItem) . '-report',
+        'permission' => 'access CiviCRM pivot table reports',
+        'separator' => 0,
+        'parentID' => $pivotID,
+        'navID' => $navId,
+        'active' => 1
+      ),
+    );
+  }
 }


### PR DESCRIPTION
## Overview
It is required to add an item to the reports menu for each enabled entity on pivot report.

## Before
There was only one link for Pivot Report, which loaded activities report by default. From there, you could use a select field to choose the report you wanted to see.

## After
Created one child menu item of "Pivot Report" per entity. The menu is built dynamically from list of enabled entities. This way if prospects extension is not installed, the menu item for prospects will not appear.
