### PR TITLE
GS-89: Implement CSV and TSV Export Buttons

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -83,7 +83,7 @@ select.relativeFilter {
 }
 
 #pivot-report-type select.pvtRenderer {
-  width: 50em;
+  width: 30em;
 }
 
 .pvtAxisContainer li span.pvtAttr {
@@ -140,4 +140,8 @@ table.pvtUi td.pvtVertList {
   -ms-transition: none;
   -o-transition: none;
   transition: none;
+}
+
+div.right-align {
+  float: right;
 }

--- a/js/PivotReport.PivotTable.js
+++ b/js/PivotReport.PivotTable.js
@@ -413,6 +413,22 @@ CRM.PivotReport.PivotTable = (function($) {
   PivotTable.prototype.postRender = function() {
     this.initDateFilters();
     this.uxImprovements();
+    this.setUpExportButtons();
+  }
+
+  /**
+   * Returns current date in YYYYMMDD_HHII format.
+   *
+   * @returns {String}
+   */
+  PivotTable.prototype.getCurrentTimestamp = function () {
+    var now = new Date();
+    var month = now.getMonth() + 1;
+    var day = now.getDate();
+    var date = [now.getFullYear(), ('0' + month).substring(month.length), ('0' + day).substring(day.length)];
+    var time = [now.getHours(), now.getMinutes()];
+
+    return date.join('') + '_' + time.join('');
   }
 
   /**
@@ -453,6 +469,40 @@ CRM.PivotReport.PivotTable = (function($) {
         $('#cols_help_msg').hide();
       }
     });
+  }
+
+  /**
+   * Implements functionality to generate CSV and TSV export files and send their
+   * content as a download.
+   */
+  PivotTable.prototype.setUpExportButtons = function () {
+    var that = this;
+
+    $('#exportCSV').unbind().click(function () {
+      var data = new $.pivotUtilities.PivotData(that.data, that.PivotConfig.getPivotConfig());
+      var downloader = $.pivotUtilities.export_renderers["CSV Export"](data, that.PivotConfig.getPivotConfig());
+      downloader.attr('download', 'pivot_report_' + that.getCurrentTimestamp() + '.csv');
+      downloader.css('display', 'none');
+      $('#pivot-report-type').append(downloader);
+      $('#download')[0].click();
+      downloader.remove();
+    });
+
+    $('#exportTSV').unbind().click(function () {
+      var data = new $.pivotUtilities.PivotData(that.data, that.PivotConfig.getPivotConfig());
+      var downloader = $.pivotUtilities.export_renderers["TSV Export"](data, that.PivotConfig.getPivotConfig());
+      downloader.attr('download', 'pivot_report_' + that.getCurrentTimestamp() + '.tsv');
+      downloader.css('display', 'none');
+      $('#pivot-report-type').append(downloader);
+      $('#download')[0].click();
+      downloader.remove();
+    });
+
+    $('select.pvtRenderer option').each(function () {
+      if ($(this).val() == 'CSV Export' || $(this).val() == 'TSV Export') {
+        $(this).remove();
+      }
+    })
   }
 
   /**

--- a/templates/CRM/PivotReport/Page/ReportConfig.tpl
+++ b/templates/CRM/PivotReport/Page/ReportConfig.tpl
@@ -14,9 +14,9 @@
       Chart Type:
     </div>
     <div id="pivot-report-type" class="form-item"></div>
-    {if ($canManagePivotReportConfig)}
+    {if $canManagePivotReportConfig}
       <div class="form-item">
-        <input type="button" class="report-config-save-btn btn btn-primary hidden" value="{ts}Save Report{/ts}">
+        <input type="button" class="report-config-save-btn btn btn-primary" value="{ts}Save Report{/ts}" style="display: none;">
       </div>
       <div class="form-item">
         <input type="button" class="report-config-save-new-btn btn btn-primary" value="{ts}Save As New{/ts}">
@@ -25,6 +25,12 @@
         <input type="button" class="report-config-delete-btn btn btn-danger" value="{ts}Delete{/ts}">
       </div>
     {/if}
+    <div class="form-item right-align">
+      <input id="exportTSV" type="button" class="btn btn-primary" value="{ts}Export TSV{/ts}">
+    </div>
+    <div class="form-item right-align">
+      <input id="exportCSV" type="button" class="btn btn-primary" value="{ts}Export CSV{/ts}">
+    </div>
   </form>
 </div>
 <div id="">


### PR DESCRIPTION
## Overview
The requirement was to replace the current CSV and TSV Export options available on the Chart Type selection box for two distinct buttons, that should appear to the right this combo box.

## Before
In order to generate a CSV or TSV export, you had to change the Chart Type to one of the two and then click on the link appearing at the middle of the pivot report to actually download the fie.

![image](https://user-images.githubusercontent.com/21999940/32577888-4f16230c-c4a9-11e7-8cff-dceb0f9fe3a1.png)

## After
Added buttons to the form, implementing file generation using the same export renderers being used by existing pivot report. Also removed CSV and TSV export options from chart type select box.

![image](https://user-images.githubusercontent.com/21999940/32577534-44e2267a-c4a8-11e7-964d-31b2a3fddaa9.png)
