### PR TITLE
 GS-88: Add Menu Items to Navigation DB Table Instead of Using Hooks

### DIFF
--- a/CRM/PivotReport/Upgrader.php
+++ b/CRM/PivotReport/Upgrader.php
@@ -15,6 +15,7 @@ class CRM_PivotReport_Upgrader extends CRM_PivotReport_Upgrader_Base {
     $this->upgrade_0002();
     $this->upgrade_0003();
     $this->upgrade_0006();
+    $this->upgrade_0007();
 
     return TRUE;
   }
@@ -28,6 +29,8 @@ class CRM_PivotReport_Upgrader extends CRM_PivotReport_Upgrader_Base {
   {
     $this->deleteScheduledJob();
 
+    $pivotID = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Navigation', 'pivotreport', 'id', 'name');
+    CRM_Core_DAO::executeQuery("DELETE FROM `civicrm_navigation` WHERE parent_id = $pivotID");
     CRM_Core_DAO::executeQuery("DELETE FROM `civicrm_navigation` WHERE name IN ('pivotreport', 'Pivot Report Config')");
     CRM_Core_BAO_Navigation::resetNavigation();
 
@@ -144,7 +147,7 @@ class CRM_PivotReport_Upgrader extends CRM_PivotReport_Upgrader_Base {
    *
    * @return bool
    */
-  public function upgrade_0006() {
+  public function upgrade_0007() {
     $reportsNavId = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Navigation', 'Reports', 'id', 'name');
 
     CRM_Core_DAO::executeQuery("DELETE FROM `civicrm_navigation` WHERE name = 'pivotreport'");
@@ -204,7 +207,13 @@ class CRM_PivotReport_Upgrader extends CRM_PivotReport_Upgrader_Base {
   public function onEnable() {
     $this->setScheduledJobIsActive(TRUE);
 
-    CRM_Core_DAO::executeQuery("UPDATE civicrm_navigation SET is_active = 1 WHERE name IN ('pivotreport', 'Pivot Report Config')");
+    $pivotID = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Navigation', 'pivotreport', 'id', 'name');
+    CRM_Core_DAO::executeQuery("
+      UPDATE civicrm_navigation 
+      SET is_active = 1 
+      WHERE name IN ('pivotreport', 'Pivot Report Config')
+      OR parent_id = $pivotID
+    ");
     CRM_Core_BAO_Navigation::resetNavigation();
 
     return TRUE;
@@ -218,7 +227,13 @@ class CRM_PivotReport_Upgrader extends CRM_PivotReport_Upgrader_Base {
   public function onDisable() {
     $this->setScheduledJobIsActive(FALSE);
 
-    CRM_Core_DAO::executeQuery("UPDATE civicrm_navigation SET is_active = 0 WHERE name IN ('pivotreport', 'Pivot Report Config')");
+    $pivotID = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Navigation', 'pivotreport', 'id', 'name');
+    CRM_Core_DAO::executeQuery("
+      UPDATE civicrm_navigation 
+      SET is_active = 0 
+      WHERE name IN ('pivotreport', 'Pivot Report Config')
+      OR parent_id = $pivotID
+    ");
     CRM_Core_BAO_Navigation::resetNavigation();
 
     return TRUE;

--- a/CRM/PivotReport/Upgrader.php
+++ b/CRM/PivotReport/Upgrader.php
@@ -140,6 +140,63 @@ class CRM_PivotReport_Upgrader extends CRM_PivotReport_Upgrader_Base {
   }
 
   /**
+   * Add menu items for each enabled entity as a sub item of Pivot Report.
+   *
+   * @return bool
+   */
+  public function upgrade_0006() {
+    $reportsNavId = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Navigation', 'Reports', 'id', 'name');
+
+    CRM_Core_DAO::executeQuery("DELETE FROM `civicrm_navigation` WHERE name = 'pivotreport'");
+    $this->createNavigationItem(array(
+      'domain_id'  => CRM_Core_Config::domainID(),
+      'label'      => ts('Pivot Report'),
+      'name'       => 'pivotreport',
+      'url'        => '',
+      'parent_id'  => $reportsNavId,
+      'weight'     => 0,
+      'permission' => 'access CiviCRM pivot table reports',
+      'has_separator'  => 1,
+      'is_active'  => 1
+    ));
+
+    $entities = CRM_PivotReport_Entity::getSupportedEntities();
+    $pivotID = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Navigation', 'pivotreport', 'id', 'name');
+    $weight = 0;
+
+    foreach ($entities as $currentItem) {
+      $itemName = strtolower($currentItem) . '-report';
+      CRM_Core_DAO::executeQuery("DELETE FROM `civicrm_navigation` WHERE name = '$itemName'");
+      $this->createNavigationItem(array(
+        'domain_id'  => CRM_Core_Config::domainID(),
+        'label'      => ts($currentItem),
+        'name'       => $itemName,
+        'url'        => 'civicrm/' . strtolower($currentItem) . '-report',
+        'parent_id'  => $pivotID,
+        'weight'     => $weight++,
+        'permission' => 'access CiviCRM pivot table reports',
+        'has_separator'  => 0,
+        'is_active'  => 1
+      ));
+    }
+
+    CRM_Core_BAO_Navigation::resetNavigation();
+
+    return TRUE;
+  }
+
+  /**
+   * Creates new menu item using provided parameters.
+   *
+   * @param array $params
+   */
+  private function createNavigationItem($params) {
+    $navigation = new CRM_Core_DAO_Navigation();
+    $navigation->copyValues($params);
+    $navigation->save();
+  }
+
+  /**
    * Logic which is executing when enabling extension.
    * 
    * @return boolean

--- a/pivotreport.php
+++ b/pivotreport.php
@@ -186,37 +186,3 @@ function pivotreport_civicrm_entityTypes(&$entityTypes) {
     'table' => 'civicrm_pivotreport_config',
   ];
 }
-
-/**
- * Implements hook_civicrm_navigationMenu()
- *
- * @param array $params
- *   List of menu items
- */
-function pivotreport_civicrm_navigationMenu(&$params) {
-  $entities = CRM_PivotReport_Entity::getSupportedEntities();
-
-  $reportID = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Navigation', 'Reports', 'id', 'name');
-  $pivotID = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Navigation', 'pivotreport', 'id', 'name');
-  $navId = CRM_Core_DAO::singleValueQuery("SELECT max(id) FROM civicrm_navigation");
-
-  $params[$reportID]['child'][$pivotID]['attributes']['url'] = null;
-
-  $weight = 0;
-  foreach ($entities as $currentItem) {
-    $navId++;
-
-    $params[$reportID]['child'][$pivotID]['child'][$navId] = array(
-      'attributes' => array (
-        'label' => ts($currentItem),
-        'name' => strtolower($currentItem) . '-report',
-        'url' => 'civicrm/' . strtolower($currentItem) . '-report',
-        'permission' => 'access CiviCRM pivot table reports',
-        'separator' => 0,
-        'parentID' => $pivotID,
-        'navID' => $navId,
-        'active' => 1
-      ),
-    );
-  }
-}


### PR DESCRIPTION
## Overview
New menu items for each entity pivot report should be added to the database, instead of using hooks to alter the menu. These items should be added on extension installation, activated when the extension is enabled, deactivated when the extension is disabled and deleted on uninstallation.

## Before
Items were being added to the menu using hooks, which required the caches to be deleted so the menu was rebuilt. There was no separator below Pivot Report menu item.

![image](https://user-images.githubusercontent.com/21999940/32612061-41a40a36-c535-11e7-9a58-7a6b4f95d1d8.png)

## After
Menu items are added, enabled, disabled and deleted on extension installation, enabling, disabling and uninstallation, respectively. There is a separator below Pivot Report menu item.

![image](https://user-images.githubusercontent.com/21999940/32611594-12f0e23c-c534-11e7-9b95-0f4a0174fca8.png)
