### PR TITLE
GS-43: Supported entities validation

### DIFF
--- a/CRM/PivotData/AbstractData.php
+++ b/CRM/PivotData/AbstractData.php
@@ -768,6 +768,15 @@ abstract class CRM_PivotData_AbstractData implements CRM_PivotData_DataInterface
   }
 
   /**
+   * Returns apiEntityName property value.
+   *
+   * @return string
+   */
+  public function getApiEntityName() {
+    return $this->apiEntityName;
+  }
+
+  /**
    * Returns a string containing Entity index basing on Entity row.
    *
    * The Entity Index is used as a part of cache key. It may be an Entity ID, date,


### PR DESCRIPTION
On HW local site there was an error during caching Contribution entity. It was caused because CiviContribute component was disabled on the site. To fix this issue I've extended entities validation to check for API response on required entities.

Now we can define 'extensions' and 'entities' array values as requirements for any supported entity in CRM_PivotReport_Entity class. It allows to check these requirements before adding the entity to supported entities list.

For example:
  $entities = array(
    'Prospect' => array(
      '**extensions**' => array(
        'uk.co.compucorp.civicrm.prospect',
      ),
      '**entities**' => array(
        'Contribution',
        'Pledge',
      ),
    );

Additionally, each entity is validated with API call to the entity itself (even if we don't specify required entities).

For example:
  $entities = array(
    'Contribution' => array()
  );