### PR TITLE
GS-92: Multiselect fields error in pivot table

### DIFF
--- a/CRM/PivotData/AbstractData.php
+++ b/CRM/PivotData/AbstractData.php
@@ -175,12 +175,12 @@ abstract class CRM_PivotData_AbstractData implements CRM_PivotData_DataInterface
   /**
    * Returns an array containing formatted rows of specified array.
    *
-   * @param int $key
+   * @param int $baseKey
    * @param array $row
    *
    * @return array
    */
-  protected function formatRow($key, $row) {
+  protected function formatRow($baseKey, $row) {
     $fields = $this->getFields();
     $result = array();
 
@@ -195,7 +195,7 @@ abstract class CRM_PivotData_AbstractData implements CRM_PivotData_DataInterface
       $result[$label] = $formattedValue;
 
       if (is_array($formattedValue)) {
-        $this->multiValues[$key][] = $label;
+        $this->multiValues[$baseKey][] = $label;
       }
     }
 

--- a/CRM/PivotData/DataCase.php
+++ b/CRM/PivotData/DataCase.php
@@ -171,38 +171,6 @@ class CRM_PivotData_DataCase extends CRM_PivotData_AbstractData {
   }
 
   /**
-   * Returns an array containing formatted rows of specified array.
-   *
-   * @param int $key
-   * @param array $row
-   *
-   * @return array
-   */
-  protected function formatRow($key, $row) {
-    $fields = $this->getFields();
-    $result = array();
-
-    foreach ($row as $key => $value) {
-      $label = $key;
-      if (!empty($fields[$key]['title'])) {
-        $label = $fields[$key]['title'];
-      }
-      $label = ts($label);
-
-      $formattedValue = $this->formatValue($key, $value);
-      $result[$label] = $formattedValue;
-
-      if (is_array($formattedValue)) {
-        $this->multiValues[$key][] = $label;
-      }
-    }
-
-    ksort($result);
-
-    return $result;
-  }
-
-  /**
    * @inheritdoc
    */
   protected function getEntityIndex(array $row) {


### PR DESCRIPTION
There was an issue that multivalues custom fields were shown inline instead of splitting them into separated rows (which is the main idea of pivot data). It was caused by a bug in formatRow() method (used for each entity except Activity which has it's own recursive implementation of this method).

Before:
![gs-92-before2](https://user-images.githubusercontent.com/8986209/32737922-ae48bef2-c89b-11e7-833a-4a098b7b68ea.png)


After fixing:
![gs-92-after2](https://user-images.githubusercontent.com/8986209/32737928-b1ae4c24-c89b-11e7-866a-47330f8c9cfa.png)

