### PR TITLE
GS-99: Stress tests

### DIFF
--- a/js/PivotReport.PivotTable.js
+++ b/js/PivotReport.PivotTable.js
@@ -123,7 +123,7 @@ CRM.PivotReport.PivotTable = (function($) {
 
               if ($(this).text() == 'Apply' || $(this).text() == 'Cancel') {
                 $(this).on('click', function () {
-                  that.filterDateValues(fieldName);
+                  that.filterDateValues(fieldName, true);
                 });
               }
             });
@@ -151,8 +151,12 @@ CRM.PivotReport.PivotTable = (function($) {
    *
    * @param string fieldName
    *   Name of the field to be filtered
+   * @param bool applyOnly
+   *   Do we want to use filter values for apply only?
+   *   If so, then we don't change checkboxes status but only show/hide
+   *   checkboxes basing on date filter values.
    */
-  PivotTable.prototype.filterDateValues = function (fieldName) {
+  PivotTable.prototype.filterDateValues = function (fieldName, applyOnly) {
     var that = this;
     var startDateValue = $('#fld_' + fieldName + '_start').val();
     var endDateValue = $('#fld_' + fieldName + '_end').val();
@@ -166,10 +170,12 @@ CRM.PivotReport.PivotTable = (function($) {
         checked = true;
       }
 
-      if (checked == true && !$(this).is(':checked')) {
-        $(this).click();
-      } else if (checked == false && $(this).is(':checked')) {
-        $(this).click();
+      if (!applyOnly) {
+       if (checked == true && !$(this).is(':checked')) {
+          $(this).prop('checked', true).toggleClass('changed');
+        } else if (checked == false && $(this).is(':checked')) {
+          $(this).prop('checked', false).toggleClass('changed');
+        }
       }
 
       if (checked === true) {


### PR DESCRIPTION
There was a performance issue using UI date filters on Pivot Table date fields. It was caused mostly by triggering 'click' event on each date filter checkbox. Fortunatelly we can achieve the same by modifying some properties and classes for the checkboxes which is a lot faster. For me previously selecting/deselecting all dates for 6k activities took 29 seconds, now it's under 1 second.

Also I've updated filterDateValues with additional parameter allowing to use the method with 'Apply' / 'Cancel' actions and not modify the checkboxes state so it's possible to select/unselect particular date checkboxes along with using date range filters. Previously particular date checkboxes were ignored if we already defined date range values.

Before (shows only the second issue because the first one took too long to record with my gif app)
![gs-99-before](https://user-images.githubusercontent.com/8986209/32788681-2feba7e4-c95a-11e7-861a-e81a32941440.gif)

After fixing (date filtering speed + the second checkboxes issue resolved)
![gs-99-after](https://user-images.githubusercontent.com/8986209/32788705-4094f80c-c95a-11e7-98f8-4fb6fa2f13e3.gif)

After fixing - relative dates:
![gs-99-after2](https://user-images.githubusercontent.com/8986209/32791387-341868b4-c961-11e7-9ec2-9e1135b5e212.gif)
