### PR TITLE
HW-432: Pivot Report caching building improvement

### DIFF
--- a/CRM/PivotData/DataActivity.php
+++ b/CRM/PivotData/DataActivity.php
@@ -4,6 +4,10 @@
  * Provides a functionality to prepare Activity entity data for Pivot Table.
  */
 class CRM_PivotData_DataActivity extends CRM_PivotData_AbstractData {
+  /**
+   * @inheritdoc
+   */
+  const ROWS_MULTIVALUES_LIMIT = 500;
 
   /**
    * CRM_PivotData_DataActivity constructor.

--- a/CRM/PivotData/DataActivity.php
+++ b/CRM/PivotData/DataActivity.php
@@ -144,6 +144,7 @@ class CRM_PivotData_DataActivity extends CRM_PivotData_AbstractData {
         LEFT JOIN `civicrm_custom_field` f ON f.custom_group_id = g.id 
         LEFT JOIN `civicrm_option_group` og ON og.id = f.option_group_id 
         WHERE g.extends = \'Activity\' AND g.is_active = 1 AND f.is_active = 1 
+        AND f.html_type NOT IN (\'TextArea\', \'RichTextEditor\') AND (f.data_type <> \'String\' OR (f.data_type = \'String\' AND f.html_type <> \'Text\'))
       ');
 
       while ($customFieldsResult->fetch()) {


### PR DESCRIPTION
- Excluding text/textarea custom fields from Activity Pivot Report cache building.
- Changing multivalues generated at once limit to 500 for Activity entity.