### PR TITLE
GS-91: Pivot Config ux changes

### DIFF
--- a/CRM/PivotReport/Upgrader.php
+++ b/CRM/PivotReport/Upgrader.php
@@ -189,6 +189,28 @@ class CRM_PivotReport_Upgrader extends CRM_PivotReport_Upgrader_Base {
   }
 
   /**
+   * Changes 'Pivot Report Config' label to 'Pivot Report Configuration'.
+   * @return bool
+   */
+  public function upgrade_0008() {
+    $configItem = civicrm_api3('Navigation', 'get', array(
+      'sequential' => 1,
+      'name' => 'Pivot Report Config',
+    ));
+
+    if (!empty($configItem['id'])) {
+      civicrm_api3('Navigation', 'create', array(
+        'id' => $configItem['id'],
+        'label' => ts('Pivot Report Configuration'),
+      ));
+
+      CRM_Core_BAO_Navigation::resetNavigation();
+    }
+
+    return TRUE;
+  }
+
+  /**
    * Creates new menu item using provided parameters.
    *
    * @param array $params

--- a/css/style.css
+++ b/css/style.css
@@ -154,6 +154,12 @@ div.pivot-report-output-config div.pivot-report-export-button {
   transition: none;
 }
 
+#pivot-report-preloader .progress .progress-value {
+  position: absolute;
+  width: 100%;
+  text-align: center;
+}
+
 div.right-align {
   float: right;
 }

--- a/css/style_admin.css
+++ b/css/style_admin.css
@@ -1,3 +1,14 @@
+/* Pivot Report cache rebuilding */
+
+div.rebuild-pivot-report-cache div.in-progress {
+  display: inline;
+}
+
+div.rebuild-pivot-report-cache div.in-progress i.fa-spin {
+  font-size: 1.5em;
+  vertical-align: middle;
+}
+
 /* Pivot Table progress bar */
 
 #pivot-report-preloader {
@@ -10,6 +21,12 @@
   -ms-transition: none;
   -o-transition: none;
   transition: none;
+}
+
+#pivot-report-preloader .progress .progress-value {
+  position: absolute;
+  width: 100%;
+  text-align: center;
 }
 
 #pivot-report-admin .build-date-time {

--- a/js/PivotReport.Admin.js
+++ b/js/PivotReport.Admin.js
@@ -80,6 +80,8 @@ CRM.PivotReport.Admin = (function($) {
           that.Preloader.hide();
           that.updateBuildDateTime();
 
+          $('input.build-cache-button', that.container).prop('disabled', false);
+
           CRM.alert('All Pivot Reports have been refreshed.', null, 'success');
         }
 
@@ -130,6 +132,8 @@ CRM.PivotReport.Admin = (function($) {
     $('input[type="button"].build-cache-button').click(function(e) {
       CRM.confirm({message: 'This operation may take some time to build the cache. Do you really want to build the cache for all supported entities?' })
       .on('crmConfirm:yes', function() {
+        $('input.build-cache-button', that.container).prop('disabled', true);
+
         that.buildCache();
       });
     });

--- a/js/PivotReport.Admin.js
+++ b/js/PivotReport.Admin.js
@@ -81,6 +81,7 @@ CRM.PivotReport.Admin = (function($) {
           that.updateBuildDateTime();
 
           $('input.build-cache-button', that.container).prop('disabled', false);
+          $('div.in-progress', that.container).addClass('hidden');
 
           CRM.alert('All Pivot Reports have been refreshed.', null, 'success');
         }
@@ -133,6 +134,7 @@ CRM.PivotReport.Admin = (function($) {
       CRM.confirm({message: 'This operation may take some time to build the cache. Do you really want to build the cache for all supported entities?' })
       .on('crmConfirm:yes', function() {
         $('input.build-cache-button', that.container).prop('disabled', true);
+        $('div.in-progress', that.container).removeClass('hidden');
 
         that.buildCache();
       });

--- a/js/PivotReport.Preloader.js
+++ b/js/PivotReport.Preloader.js
@@ -9,6 +9,7 @@ CRM.PivotReport.Preloader = (function($) {
     this.container = CRM.$('#pivot-report-preloader');
     this.title = CRM.$('.pivot-report-loading-title', this.container);
     this.progressBar = CRM.$('.progress > .progress-bar', this.container);
+    this.progressValue = CRM.$('.progress > .progress-value', this.container);
   }
 
   /**
@@ -49,9 +50,8 @@ CRM.PivotReport.Preloader = (function($) {
   Preloader.prototype.setValue = function(value) {
     var progressValue = value + '%';
 
-    this.progressBar.attr('aria-valuenow', progressValue);
     this.progressBar.css('width', progressValue);
-    this.progressBar.text(progressValue);
+    this.progressValue.text(progressValue);
   }
 
   return Preloader;

--- a/templates/CRM/PivotReport/Page/PivotReportAdmin.tpl
+++ b/templates/CRM/PivotReport/Page/PivotReportAdmin.tpl
@@ -1,9 +1,15 @@
 <div id="pivot-report-admin">
-  <input class="build-cache-button" type="button" value="{ts}Refresh All Pivot Reports{/ts}">
+  <div class="rebuild-pivot-report-cache">
+    <input class="build-cache-button" type="button" value="{ts}Refresh All Pivot Reports{/ts}">
+    <div class="in-progress hidden">
+      <i class="fa fa-spinner fa-spin"></i>
+      <span>{ts}Building report cache. This might take a few minutes.{/ts}</span>
+    </div>
 
-  {include file="CRM/PivotReport/Page/ReportPreloader.tpl"}
+    {include file="CRM/PivotReport/Page/ReportPreloader.tpl"}
 
-  <div class="build-date-time">{ts}Last refresh{/ts}: <span>{if $buildDateTime}{$buildDateTime|crmDate}{else}{ts}Never{/ts}{/if}</span></div>
+    <div class="build-date-time">{ts}Last refresh{/ts}: <span>{if $buildDateTime}{$buildDateTime|crmDate}{else}{ts}Never{/ts}{/if}</span></div>
+  </div>
 </div>
 
 {literal}

--- a/templates/CRM/PivotReport/Page/ReportPreloader.tpl
+++ b/templates/CRM/PivotReport/Page/ReportPreloader.tpl
@@ -2,5 +2,6 @@
   <div class="pivot-report-loading-title"></div>
   <div class="progress">
     <div class="progress-bar" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
+    <div class="progress-value"></div>
   </div>
 </div>


### PR DESCRIPTION
- Renaming menu item from "Pivot Report Config" to "Pivot Report Configuration".
- Adding in-progress info with spinner icon.
- Modifying progress bar (also for data loading)
- Disabling "Refresh All Pivot Reports" button when cache rebuilding is in progress.

![gs-91-updated](https://user-images.githubusercontent.com/8986209/32898422-6c256d8c-cae8-11e7-9eca-407a58beedfb.gif)
