### PR TITLE
HW-433: Progress bar issue

### DIFF
--- a/CRM/PivotCache/AbstractGroup.php
+++ b/CRM/PivotCache/AbstractGroup.php
@@ -110,6 +110,35 @@ abstract class CRM_PivotCache_AbstractGroup implements CRM_PivotCache_GroupInter
   }
 
   /**
+   * @inheritdoc
+   */
+  public function query($page, array $params) {
+    $cache = new CRM_PivotReport_DAO_PivotReportCache();
+
+    $cache->group_name = $this->getName();
+
+    $this->customizeQuery($cache, $page, $params);
+
+    $cache->whereAdd("path NOT IN ('header', 'entityCount', 'pivotCount')");
+
+    $cache->orderBy('path ASC');
+
+    $cache->find();
+
+    return $cache;
+  }
+
+  /**
+   * Allows to modify Pivot Report Cache DAO object before executing the query.
+   *
+   * @param \CRM_PivotReport_DAO_PivotReportCache $queryObject
+   * @param int $page
+   * @param array $params
+   */
+  protected function customizeQuery(CRM_PivotReport_DAO_PivotReportCache $queryObject, $page, array $params) {
+  }
+
+  /**
    * Gets a cache path string by specified index and page.
    *
    * @param string $index

--- a/CRM/PivotCache/AbstractGroup.php
+++ b/CRM/PivotCache/AbstractGroup.php
@@ -54,7 +54,7 @@ abstract class CRM_PivotCache_AbstractGroup implements CRM_PivotCache_GroupInter
    * @inheritdoc
    */
   public function getHeader() {
-    return json_decode(CRM_PivotReport_BAO_PivotReportCache::getItem($this->getName(), 'header'));
+    return json_decode($this->getCacheValue('header'));
   }
 
   /**
@@ -62,7 +62,21 @@ abstract class CRM_PivotCache_AbstractGroup implements CRM_PivotCache_GroupInter
    */
   public function cacheHeader(array $rows) {
     $jsonHeader = json_encode($this->sortHeader($rows));
-    CRM_PivotReport_BAO_PivotReportCache::setItem($jsonHeader, $this->getName(), 'header');
+    $this->setCacheValue('header', $jsonHeader);
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public function setCacheValue($key, $value) {
+    CRM_PivotReport_BAO_PivotReportCache::setItem($value, $this->getName(), $key);
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public function getCacheValue($key) {
+    return CRM_PivotReport_BAO_PivotReportCache::getItem($this->getName(), $key);
   }
 
   /**
@@ -90,7 +104,7 @@ abstract class CRM_PivotCache_AbstractGroup implements CRM_PivotCache_GroupInter
     $count = count($page->getData());
 
     $jsonData = json_encode($page->getData());
-    CRM_PivotReport_BAO_PivotReportCache::setItem($jsonData, $this->getName(), $this->getPath($page->getIndex(), $page->getPage()));
+    $this->setCacheValue($this->getPath($page->getIndex(), $page->getPage()), $jsonData);
 
     return $count;
   }
@@ -118,7 +132,7 @@ abstract class CRM_PivotCache_AbstractGroup implements CRM_PivotCache_GroupInter
     $cache = new CRM_PivotReport_DAO_PivotReportCache();
 
     $cache->group_name = $this->getName();
-    $cache->whereAdd("path = 'header'");
+    $cache->whereAdd("path = 'pivotCount'");
     $cache->whereAdd("group_name = '{$this->getName()}'");
     $cache->orderBy('path ASC');
     $cache->find();

--- a/CRM/PivotCache/GroupActivity.php
+++ b/CRM/PivotCache/GroupActivity.php
@@ -41,7 +41,7 @@ class CRM_PivotCache_GroupActivity extends CRM_PivotCache_AbstractGroup {
       $cache->whereAdd($whereEndDate);
     }
 
-    $cache->whereAdd("path <> 'header'");
+    $cache->whereAdd("path NOT IN ('header', 'entityCount', 'pivotCount')");
 
     $cache->orderBy('path ASC');
 

--- a/CRM/PivotCache/GroupActivity.php
+++ b/CRM/PivotCache/GroupActivity.php
@@ -12,11 +12,7 @@ class CRM_PivotCache_GroupActivity extends CRM_PivotCache_AbstractGroup {
   /**
    * @inheritdoc
    */
-  public function query($page, array $params) {
-    $cache = new CRM_PivotReport_DAO_PivotReportCache();
-
-    $cache->group_name = $this->getName();
-
+  protected function customizeQuery(CRM_PivotReport_DAO_PivotReportCache $queryObject, $page, array $params) {
     if (!empty($params['keyvalue_from'])) {
       $whereStartDate = CRM_Core_DAO::createSQLFilter(
         'path',
@@ -26,7 +22,7 @@ class CRM_PivotCache_GroupActivity extends CRM_PivotCache_AbstractGroup {
         'String'
       );
 
-      $cache->whereAdd($whereStartDate);
+      $queryObject->whereAdd($whereStartDate);
     }
 
     if (!empty($params['keyvalue_to'])) {
@@ -38,15 +34,7 @@ class CRM_PivotCache_GroupActivity extends CRM_PivotCache_AbstractGroup {
         'String'
       );
 
-      $cache->whereAdd($whereEndDate);
+      $queryObject->whereAdd($whereEndDate);
     }
-
-    $cache->whereAdd("path NOT IN ('header', 'entityCount', 'pivotCount')");
-
-    $cache->orderBy('path ASC');
-
-    $cache->find();
-
-    return $cache;
   }
 }

--- a/CRM/PivotCache/GroupCase.php
+++ b/CRM/PivotCache/GroupCase.php
@@ -8,21 +8,4 @@ class CRM_PivotCache_GroupCase extends CRM_PivotCache_AbstractGroup {
   public function __construct($name = NULL) {
     parent::__construct('Case');
   }
-
-  /**
-   * @inheritdoc
-   */
-  public function query($page, array $params) {
-    $cache = new CRM_PivotReport_DAO_PivotReportCache();
-
-    $cache->group_name = $this->getName();
-
-    $cache->whereAdd("path NOT IN ('header', 'entityCount', 'pivotCount')");
-
-    $cache->orderBy('path ASC');
-
-    $cache->find();
-
-    return $cache;
-  }
 }

--- a/CRM/PivotCache/GroupCase.php
+++ b/CRM/PivotCache/GroupCase.php
@@ -17,7 +17,7 @@ class CRM_PivotCache_GroupCase extends CRM_PivotCache_AbstractGroup {
 
     $cache->group_name = $this->getName();
 
-    $cache->whereAdd("path <> 'header'");
+    $cache->whereAdd("path NOT IN ('header', 'entityCount', 'pivotCount')");
 
     $cache->orderBy('path ASC');
 

--- a/CRM/PivotCache/GroupContribution.php
+++ b/CRM/PivotCache/GroupContribution.php
@@ -17,7 +17,7 @@ class CRM_PivotCache_GroupContribution extends CRM_PivotCache_AbstractGroup {
 
     $cache->group_name = $this->getName();
 
-    $cache->whereAdd("path <> 'header'");
+    $cache->whereAdd("path NOT IN ('header', 'entityCount', 'pivotCount')");
 
     $cache->orderBy('path ASC');
 

--- a/CRM/PivotCache/GroupContribution.php
+++ b/CRM/PivotCache/GroupContribution.php
@@ -8,21 +8,4 @@ class CRM_PivotCache_GroupContribution extends CRM_PivotCache_AbstractGroup {
   public function __construct($name = NULL) {
     parent::__construct('Contribution');
   }
-
-  /**
-   * @inheritdoc
-   */
-  public function query($page, array $params) {
-    $cache = new CRM_PivotReport_DAO_PivotReportCache();
-
-    $cache->group_name = $this->getName();
-
-    $cache->whereAdd("path NOT IN ('header', 'entityCount', 'pivotCount')");
-
-    $cache->orderBy('path ASC');
-
-    $cache->find();
-
-    return $cache;
-  }
 }

--- a/CRM/PivotCache/GroupMembership.php
+++ b/CRM/PivotCache/GroupMembership.php
@@ -8,21 +8,4 @@ class CRM_PivotCache_GroupMembership extends CRM_PivotCache_AbstractGroup {
   public function __construct($name = NULL) {
     parent::__construct('Membership');
   }
-
-  /**
-   * @inheritdoc
-   */
-  public function query($page, array $params) {
-    $cache = new CRM_PivotReport_DAO_PivotReportCache();
-
-    $cache->group_name = $this->getName();
-
-    $cache->whereAdd("path NOT IN ('header', 'entityCount', 'pivotCount')");
-
-    $cache->orderBy('path ASC');
-
-    $cache->find();
-
-    return $cache;
-  }
 }

--- a/CRM/PivotCache/GroupMembership.php
+++ b/CRM/PivotCache/GroupMembership.php
@@ -17,7 +17,7 @@ class CRM_PivotCache_GroupMembership extends CRM_PivotCache_AbstractGroup {
 
     $cache->group_name = $this->getName();
 
-    $cache->whereAdd("path <> 'header'");
+    $cache->whereAdd("path NOT IN ('header', 'entityCount', 'pivotCount')");
 
     $cache->orderBy('path ASC');
 

--- a/CRM/PivotCache/GroupProspect.php
+++ b/CRM/PivotCache/GroupProspect.php
@@ -8,21 +8,4 @@ class CRM_PivotCache_GroupProspect extends CRM_PivotCache_AbstractGroup {
   public function __construct($name = NULL) {
     parent::__construct('Prospect');
   }
-
-  /**
-   * @inheritdoc
-   */
-  public function query($page, array $params) {
-    $cache = new CRM_PivotReport_DAO_PivotReportCache();
-
-    $cache->group_name = $this->getName();
-
-    $cache->whereAdd("path NOT IN ('header', 'entityCount', 'pivotCount')");
-
-    $cache->orderBy('path ASC');
-
-    $cache->find();
-
-    return $cache;
-  }
 }

--- a/CRM/PivotCache/GroupProspect.php
+++ b/CRM/PivotCache/GroupProspect.php
@@ -17,7 +17,7 @@ class CRM_PivotCache_GroupProspect extends CRM_PivotCache_AbstractGroup {
 
     $cache->group_name = $this->getName();
 
-    $cache->whereAdd("path <> 'header'");
+    $cache->whereAdd("path NOT IN ('header', 'entityCount', 'pivotCount')");
 
     $cache->orderBy('path ASC');
 

--- a/CRM/PivotData/AbstractData.php
+++ b/CRM/PivotData/AbstractData.php
@@ -221,6 +221,7 @@ abstract class CRM_PivotData_AbstractData implements CRM_PivotData_DataInterface
     $result = $this->rebuildData($cacheGroup, $params);
 
     $this->rebuildHeader($cacheGroup, array_merge($this->emptyRow, $this->additionalHeaderFields));
+    $this->rebuildPivotCount($cacheGroup, $result['count']);
 
     return array(
       array(

--- a/CRM/PivotData/AbstractData.php
+++ b/CRM/PivotData/AbstractData.php
@@ -215,6 +215,9 @@ abstract class CRM_PivotData_AbstractData implements CRM_PivotData_DataInterface
 
     $cacheGroup->clear();
 
+    $totalCount = $this->getCount($params);
+    $this->rebuildEntityCount($cacheGroup, $totalCount);
+
     $result = $this->rebuildData($cacheGroup, $params);
 
     $this->rebuildHeader($cacheGroup, array_merge($this->emptyRow, $this->additionalHeaderFields));
@@ -230,18 +233,22 @@ abstract class CRM_PivotData_AbstractData implements CRM_PivotData_DataInterface
   /**
    * @inheritdoc
    */
-  public function rebuildCachePartial(AbstractGroup $cacheGroup, array $params, $offset, $multiValuesOffset, $index, $page) {
+  public function rebuildCachePartial(AbstractGroup $cacheGroup, array $params, $offset, $multiValuesOffset, $index, $page, $pivotCount) {
     $this->emptyRow = $this->getEmptyRow();
     $this->multiValues = array();
 
     if (!$offset) {
       $cacheGroup->clear();
+
+      $totalCount = $this->getCount($params);
+      $this->rebuildEntityCount($cacheGroup, $totalCount);
     }
 
     $result = $this->rebuildData($cacheGroup, $params, $offset, $offset + $this::ROWS_API_LIMIT, $multiValuesOffset, $index, $page, TRUE);
 
     if (!$result['count']) {
       $this->rebuildHeader($cacheGroup, array_merge($this->emptyRow, $this->additionalHeaderFields));
+      $this->rebuildPivotCount($cacheGroup, $pivotCount);
     }
 
     return $result;
@@ -293,6 +300,44 @@ abstract class CRM_PivotData_AbstractData implements CRM_PivotData_DataInterface
    */
   public function rebuildHeader(AbstractGroup $cacheGroup, array $header) {
     $cacheGroup->cacheHeader($header);
+  }
+
+  /**
+   * Rebuilds entity count cache value.
+   *
+   * @param \CRM_PivotCache_AbstractGroup $cacheGroup
+   * @param int $entityCount
+   */
+  public function rebuildEntityCount(AbstractGroup $cacheGroup, $entityCount) {
+    $cacheGroup->setCacheValue('entityCount', $entityCount);
+  }
+
+  /**
+   * Returns entity count cache value.
+   *
+   * @param \CRM_PivotCache_AbstractGroup $cacheGroup
+   */
+  public function getEntityCount(AbstractGroup $cacheGroup) {
+    return $cacheGroup->getCacheValue('entityCount');
+  }
+
+  /**
+   * Rebuilds pivot count cache value.
+   *
+   * @param \CRM_PivotCache_AbstractGroup $cacheGroup
+   * @param int $pivotCount
+   */
+  public function rebuildPivotCount(AbstractGroup $cacheGroup, $pivotCount) {
+    $cacheGroup->setCacheValue('pivotCount', $pivotCount);
+  }
+
+  /**
+   * Returns pivot count cache value.
+   *
+   * @param \CRM_PivotCache_AbstractGroup $cacheGroup
+   */
+  public function getPivotCount(AbstractGroup $cacheGroup) {
+    return $cacheGroup->getCacheValue('pivotCount');
   }
 
   /**

--- a/CRM/PivotData/DataCase.php
+++ b/CRM/PivotData/DataCase.php
@@ -22,7 +22,7 @@ class CRM_PivotData_DataCase extends CRM_PivotData_AbstractData {
       'api.Contact.get' => array('id' => '$value.client_id', 'return' => array('id', 'contact_type', 'contact_sub_type', 'display_name')),
       'return' => array_merge($this->getCaseFields(), array('contacts', 'contact_id')),
       'options' => array(
-        'sort' => 'start_date ASC',
+        'sort' => 'start_date ASC, id ASC',
         'limit' => self::ROWS_API_LIMIT,
       ),
     );

--- a/CRM/PivotData/DataContribution.php
+++ b/CRM/PivotData/DataContribution.php
@@ -25,7 +25,7 @@ class CRM_PivotData_DataContribution extends CRM_PivotData_AbstractData {
         'return' => array('display_name', 'sort_name', 'contact_type')
       ),
       'options' => array(
-        'sort' => 'receive_date ASC',
+        'sort' => 'receive_date ASC, id ASC',
         'limit' => self::ROWS_API_LIMIT,
       ),
     );

--- a/CRM/PivotData/DataInterface.php
+++ b/CRM/PivotData/DataInterface.php
@@ -40,10 +40,11 @@ interface CRM_PivotData_DataInterface {
    * @param int $multiValuesOffset
    * @param string $index
    * @param int $page
+   * @param int $pivotCount
    *
    * @return array
    */
-  public function rebuildCachePartial(AbstractGroup $cacheGroup, array $params, $offset, $multiValuesOffset, $index, $page);
+  public function rebuildCachePartial(AbstractGroup $cacheGroup, array $params, $offset, $multiValuesOffset, $index, $page, $pivotCount);
 
   /**
    * Rebuilds entity data cache using entity paginated results.

--- a/CRM/PivotData/DataMembership.php
+++ b/CRM/PivotData/DataMembership.php
@@ -25,7 +25,7 @@ class CRM_PivotData_DataMembership extends CRM_PivotData_AbstractData {
         'return' => array('display_name', 'sort_name', 'contact_type')
       ),
       'options' => array(
-        'sort' => 'join_date ASC',
+        'sort' => 'join_date ASC, id ASC',
         'limit' => self::ROWS_API_LIMIT,
       ),
     );
@@ -148,8 +148,6 @@ class CRM_PivotData_DataMembership extends CRM_PivotData_AbstractData {
    */
   public function getCount(array $params = array()) {
     $apiParams = array(
-      'is_current_revision' => 1,
-      'is_deleted' => 0,
       'is_test' => 0,
     );
 

--- a/api/v3/PivotReport.php
+++ b/api/v3/PivotReport.php
@@ -96,6 +96,7 @@ function civicrm_api3_pivot_report_rebuildcachepartial($params) {
   $multiValuesOffset = !empty($params['multiValuesOffset']) ? (int) $params['multiValuesOffset'] : 0;
   $index = !empty($params['index']) ? $params['index'] : NULL;
   $page = !empty($params['page']) ? (int) $params['page'] : 0;
+  $pivotCount = !empty($params['pivotCount']) ? (int) $params['pivotCount'] : 0;
 
   $entityInstance = new CRM_PivotReport_Entity($entity);
   $result = $entityInstance->getDataInstance()->rebuildCachePartial(
@@ -104,7 +105,8 @@ function civicrm_api3_pivot_report_rebuildcachepartial($params) {
     $offset,
     $multiValuesOffset,
     $index,
-    $page
+    $page,
+    $pivotCount
   );
 
   return civicrm_api3_create_success(
@@ -195,6 +197,42 @@ function civicrm_api3_pivot_report_getcount($params) {
 
   return civicrm_api3_create_success(
     (int) $entityInstance->getDataInstance()->getCount(),
+    $params
+  );
+}
+
+/**
+ * PivotReport.getentitycount API
+ *
+ * @param array $params
+ * @return array API result descriptor
+ * @throws API_Exception
+ */
+function civicrm_api3_pivot_report_getentitycount($params) {
+  $entity = !empty($params['entity']) ? $params['entity'] : NULL;
+
+  $entityInstance = new CRM_PivotReport_Entity($entity);
+
+  return civicrm_api3_create_success(
+    (int) $entityInstance->getDataInstance()->getEntityCount($entityInstance->getGroupInstance()),
+    $params
+  );
+}
+
+/**
+ * PivotReport.getpivotcount API
+ *
+ * @param array $params
+ * @return array API result descriptor
+ * @throws API_Exception
+ */
+function civicrm_api3_pivot_report_getpivotcount($params) {
+  $entity = !empty($params['entity']) ? $params['entity'] : NULL;
+
+  $entityInstance = new CRM_PivotReport_Entity($entity);
+
+  return civicrm_api3_create_success(
+    (int) $entityInstance->getDataInstance()->getPivotCount($entityInstance->getGroupInstance()),
     $params
   );
 }

--- a/js/PivotReport.Admin.js
+++ b/js/PivotReport.Admin.js
@@ -9,6 +9,7 @@ CRM.PivotReport.Admin = (function($) {
     this.container = $('#pivot-report-admin');
     this.totalCount = 0;
     this.loadedCount = {};
+    this.cachedPivotCount = {};
     this.Preloader = new CRM.PivotReport.Preloader();
     this.Preloader.hide();
 
@@ -43,6 +44,7 @@ CRM.PivotReport.Admin = (function($) {
 
       for (var i in result.values[0]) {
         that.loadedCount[i] = 0;
+        that.cachedPivotCount[i] = 0;
         that.cacheEntity(i, 0, 0, null, 0, result.values[0][i]);
       }
     });
@@ -66,9 +68,11 @@ CRM.PivotReport.Admin = (function($) {
         offset: offset,
         multiValuesOffset: multiValuesOffset,
         index: index,
-        page: page
+        page: page,
+        pivotCount: that.cachedPivotCount[entity]
     }).done(function(result) {
       that.loadedCount[entity] = offset;
+      that.cachedPivotCount[entity] += result.values.count;
 
       var progressValue = parseInt((that.getTotalLoadedCount() / that.totalCount) * 100, 10);
       that.Preloader.setValue(progressValue);

--- a/js/PivotReport.PivotTable.js
+++ b/js/PivotReport.PivotTable.js
@@ -47,7 +47,6 @@ CRM.PivotReport.PivotTable = (function($) {
 
     this.removePrintIcon();
     this.initFilterForm();
-    this.initUI();
     this.initPivotDataLoading();
     this.checkCacheBuilt();
   };
@@ -262,51 +261,6 @@ CRM.PivotReport.PivotTable = (function($) {
 
     this.config.initFilterForm(this.pivotReportKeyValueFrom, this.pivotReportKeyValueTo);
   };
-
-  /**
-   * Handles UI events.
-   */
-  PivotTable.prototype.initUI = function() {
-    var that = this;
-
-    $('input[type="button"].build-cache-button').click(function(e) {
-      CRM.confirm({message: 'This operation may take some time to build the cache. Do you really want to build the cache for ' + that.config.entityName + ' data?' })
-      .on('crmConfirm:yes', function() {
-        that.Preloader.reset();
-        that.Preloader.setTitle('Building cache');
-        that.Preloader.show();
-
-        CRM.api3(that.config.entityName, 'getcount', that.config.getCountParams()).done(function(result) {
-           that.rebuildCache(0, 0, null, 0, result.result);
-        });
-      });
-    });
-  };
-
-  PivotTable.prototype.rebuildCache = function(offset, multiValuesOffset, index, page, totalCount) {
-    var that = this;
-
-    CRM.api3('PivotReport', 'rebuildcachepartial', {
-        entity: that.config.entityName,
-        offset: offset,
-        multiValuesOffset: multiValuesOffset,
-        index: index,
-        page: page
-      }).done(function(result) {
-      if (parseInt(result.values.count, 10) === 0) {
-        that.Preloader.hide();
-        that.config.cacheBuilt = true;
-        that.checkCacheBuilt();
-        that.initPivotDataLoading();
-
-        return;
-      }
-
-      var progressValue = parseInt((offset / totalCount) * 100, 10);
-      that.Preloader.setValue(progressValue);
-      that.rebuildCache(result.values.offset, result.values.multiValuesOffset, result.values.index, result.values.page, totalCount);
-    });
-  }
 
   /**
    * Loads header, checks total number of items and then starts data fetching.

--- a/js/PivotReport.PivotTable.js
+++ b/js/PivotReport.PivotTable.js
@@ -10,7 +10,6 @@ CRM.PivotReport.PivotTable = (function($) {
   function PivotTable(config) {
     var defaults = {
       'entityName': null,
-      'uniqueKey': 'ID',
       'cacheBuilt': true,
       'filter': false,
       'initialLoad': {
@@ -34,6 +33,7 @@ CRM.PivotReport.PivotTable = (function($) {
     this.header = [];
     this.data = [];
     this.total = 0;
+    this.pivotCount = 0;
     this.totalLoaded = 0;
     this.uniqueLoaded = [];
     this.pivotReportForm = null;
@@ -274,6 +274,7 @@ CRM.PivotReport.PivotTable = (function($) {
       }],
       'getHeader': ['PivotReport', 'getheader', {'entity': this.config.entityName}],
       'getCount': [this.config.entityName, 'getcount', that.config.getCountParams()],
+      'getPivotCount': ['PivotReport', 'getpivotcount', {'entity': this.config.entityName}],
       'dateFields': ['PivotReport', 'getdatefields', {entity: this.config.entityName}],
       'relativeFilters': ['OptionValue', 'get', {
         'sequential': 1,
@@ -286,6 +287,7 @@ CRM.PivotReport.PivotTable = (function($) {
       that.relativeFilters = result.relativeFilters.values;
       that.header = result.getHeader.values;
       that.total = parseInt(result.getCount, 10);
+      that.pivotCount = parseInt(result.getPivotCount.values, 10);
       that.crmConfig = result.getConfig.values[0];
 
       $.each(that.dateFields, function (i, value) {
@@ -482,12 +484,10 @@ CRM.PivotReport.PivotTable = (function($) {
         row[that.header[j]] = data[i][j];
       }
 
-      that.uniqueLoaded[row[that.config.uniqueKey]] = 1;
-
       result.push(row);
     }
 
-    this.totalLoaded = that.uniqueLoaded.length;
+    this.totalLoaded += result.length;
 
     return result;
   };
@@ -554,8 +554,8 @@ CRM.PivotReport.PivotTable = (function($) {
     this.Preloader.setTitle('Loading data');
     this.Preloader.show();
 
-    CRM.api3(this.config.entityName, 'getcount', this.config.getCountParams()).done(function(result) {
-        var totalCount = parseInt(result.result, 10);
+    CRM.api3('PivotReport', 'getpivotcount', {'entity': this.config.entityName}).done(function(result) {
+        var totalCount = parseInt(result.values, 10);
 
         that.loadData({
           "keyvalue_from": null,

--- a/templates/CRM/PivotReport/Page/ActivityReport.tpl
+++ b/templates/CRM/PivotReport/Page/ActivityReport.tpl
@@ -22,7 +22,6 @@
     CRM.$(function ($) {
       new CRM.PivotReport.PivotTable({
         'entityName': 'Activity',
-        'uniqueKey': 'Activity ID',
         'cacheBuilt': {/literal}{$cacheBuilt|var_export:true}{literal},
         'filter': true,
         'filterField': 'Activity Date',

--- a/templates/CRM/PivotReport/Page/CaseReport.tpl
+++ b/templates/CRM/PivotReport/Page/CaseReport.tpl
@@ -3,7 +3,6 @@
     CRM.$(function ($) {
       new CRM.PivotReport.PivotTable({
         'entityName': 'Case',
-        'uniqueKey': 'Case ID',
         'cacheBuilt': {/literal}{$cacheBuilt|var_export:true}{literal},
       });
     });

--- a/templates/CRM/PivotReport/Page/ContributionReport.tpl
+++ b/templates/CRM/PivotReport/Page/ContributionReport.tpl
@@ -3,7 +3,6 @@
     CRM.$(function ($) {
       new CRM.PivotReport.PivotTable({
         'entityName': 'Contribution',
-        'uniqueKey': 'Contribution ID',
         'cacheBuilt': {/literal}{$cacheBuilt|var_export:true}{literal},
       });
     });

--- a/templates/CRM/PivotReport/Page/MembershipReport.tpl
+++ b/templates/CRM/PivotReport/Page/MembershipReport.tpl
@@ -3,7 +3,6 @@
     CRM.$(function ($) {
       new CRM.PivotReport.PivotTable({
         'entityName': 'Membership',
-        'uniqueKey': 'Membership ID',
         'cacheBuilt': {/literal}{$cacheBuilt|var_export:true}{literal},
       });
     });

--- a/templates/CRM/PivotReport/Page/ProspectReport.tpl
+++ b/templates/CRM/PivotReport/Page/ProspectReport.tpl
@@ -3,7 +3,6 @@
     CRM.$(function ($) {
       new CRM.PivotReport.PivotTable({
         'entityName': 'Prospect',
-        'uniqueKey': 'Case ID',
         'cacheBuilt': {/literal}{$cacheBuilt|var_export:true}{literal},
       });
     });


### PR DESCRIPTION
There was an issue with progress bar loading cached data on some sites. It was causing by different number of cached data rows comparing to actual Entity rows (because of multivalues rows extending the total number of cached data).

Fixing it required to store total cached rows number into cache and then use them instead of requesting particular entity's for 'getcount' API action. Also it's more proper to store cached number of records and rely on them instead of API's 'getcount' response because the number of entities records may change in time comparing to the cached records.

Also I've added unique ID columns to SQL when retrieving cached data (not defining it might cause to return the data with random order).

I've also removed cache rebuilding functionality from Pivot Table page UI scripts (as we don't use it to rebuild the cache anymore).