### PR TITLE
HW-433: Pivot Report rebuild cache with cron job

### DIFF
--- a/CRM/PivotCache/AbstractGroup.php
+++ b/CRM/PivotCache/AbstractGroup.php
@@ -119,7 +119,7 @@ abstract class CRM_PivotCache_AbstractGroup implements CRM_PivotCache_GroupInter
 
     $this->customizeQuery($cache, $page, $params);
 
-    $cache->whereAdd("path NOT IN ('header', 'entityCount', 'pivotCount')");
+    $cache->whereAdd("path NOT IN ('header', 'entityCount', 'pivotCount') AND is_active = 1");
 
     $cache->orderBy('path ASC');
 
@@ -163,6 +163,7 @@ abstract class CRM_PivotCache_AbstractGroup implements CRM_PivotCache_GroupInter
     $cache->group_name = $this->getName();
     $cache->whereAdd("path = 'pivotCount'");
     $cache->whereAdd("group_name = '{$this->getName()}'");
+    $cache->whereAdd("is_active = 1");
     $cache->orderBy('path ASC');
     $cache->find();
 

--- a/CRM/PivotCache/AbstractGroup.php
+++ b/CRM/PivotCache/AbstractGroup.php
@@ -39,7 +39,7 @@ abstract class CRM_PivotCache_AbstractGroup implements CRM_PivotCache_GroupInter
    *
    * @return string
    */
-  protected function getName() {
+  public function getName() {
     return $this->name;
   }
 

--- a/CRM/PivotCache/PivotReportCronJobStatus.php
+++ b/CRM/PivotCache/PivotReportCronJobStatus.php
@@ -1,0 +1,225 @@
+<?php
+
+use CRM_PivotReport_Entity as Entity;
+use CRM_PivotReport_BAO_PivotReportCache as PivotReportCache;
+
+/**
+ * Reflects Cron Job Status values used to process cache building with
+ * continous calls.
+ */
+class CRM_PivotCache_PivotReportCronJobStatus {
+
+  /**
+   * Entity value.
+   */
+  private $entity;
+
+  /**
+   * Offset value.
+   *
+   * @var int
+   */
+  private $offset;
+
+  /**
+   * MultiValues offset value.
+   *
+   * @var int
+   */
+  private $multiValuesOffset;
+
+  /**
+   * Index value.
+   *
+   * @var string
+   */
+  private $index;
+
+  /**
+   * Page value.
+   *
+   * @var int
+   */
+  private $page;
+
+  /**
+   * Pivot Count value.
+   *
+   * @var int
+   */
+  private $pivotCount;
+
+  /**
+   * Initializes Cron Job Status object with latest values from cache
+   * or with defaults if cache values don't esist.
+   */
+  public function __construct() {
+    $values = PivotReportCache::getItem('admin', 'cron_job_status');
+
+    $defaultEntity = array_shift(Entity::getSupportedEntities());
+
+    $this->entity = !empty($values['entity']) ? $values['entity'] : $defaultEntity;
+    $this->offset = !empty($values['offset']) ? $values['offset'] : 0;
+    $this->multiValuesOffset = !empty($values['multiValuesOffset']) ? $values['multiValuesOffset'] : 0;
+    $this->index = !empty($values['index']) ? $values['index'] : NULL;
+    $this->page = !empty($values['page']) ? $values['page'] : NULL;
+    $this->pivotCount = !empty($values['pivotCount']) ? $values['pivotCount'] : 0;
+  }
+
+  /**
+   * Updates Cron Job Status cached values.
+   */
+  public function update() {
+    $statusValues = array(
+      'entity' => $this->entity,
+      'offset' => $this->offset,
+      'multiValuesOffset' => $this->multiValuesOffset,
+      'index' => $this->index,
+      'page' => $this->page,
+      'pivotCount' => $this->pivotCount,
+    );
+
+    PivotReportCache::setItem(
+      $statusValues,
+      'admin',
+      'cron_job_status'
+    );
+  }
+
+  /**
+   * Sets entity property on the next available entity (or NULL)
+   * and resets other Cron Job Status properties.
+   */
+  public function setupNextEntity() {
+    $this->entity = $this->getNextEntity();
+    $this->offset = 0;
+    $this->multiValuesOffset = 0;
+    $this->index = NULL;
+    $this->page = NULL;
+    $this->pivotCount = 0;
+  }
+
+  /**
+   * Returns next available entity name or NULL if there is no more entities.
+   *
+   * @return string
+   */
+  private function getNextEntity() {
+    $supportedEntities = Entity::getSupportedEntities();
+    $index = array_search($this->entity, $supportedEntities) + 1;
+
+    if ($index === count($supportedEntities)) {
+      return NULL;
+    }
+
+    return $supportedEntities[$index];
+  }
+
+  /**
+   * Gets current entity value.
+   *
+   * @return string|NULL
+   */
+  public function getEntity() {
+    return $this->entity;
+  }
+
+  /**
+   * Sets current entity value.
+   *
+   * @param string $value
+   */
+  public function setEntity($value) {
+    $this->entity = $value;
+  }
+
+  /**
+   * Gets current entity value.
+   *
+   * @return string|NULL
+   */
+  public function getOffset() {
+    return $this->offset;
+  }
+
+  /**
+   * Sets current offset value.
+   *
+   * @param string $value
+   */
+  public function setOffset($value) {
+    $this->offset = $value;
+  }
+
+  /**
+   * Gets current multiValuesOffset value.
+   *
+   * @return string|NULL
+   */
+  public function getMultiValuesOffset() {
+    return $this->multiValuesOffset;
+  }
+
+  /**
+   * Sets current multiValuesOffset value.
+   *
+   * @param string $value
+   */
+  public function setMultiValuesOffset($value) {
+    $this->multiValuesOffset = $value;
+  }
+
+  /**
+   * Gets current index value.
+   *
+   * @return string|NULL
+   */
+  public function getIndex() {
+    return $this->index;
+  }
+
+  /**
+   * Sets current index value.
+   *
+   * @param string $value
+   */
+  public function setIndex($value) {
+    $this->index = $value;
+  }
+
+  /**
+   * Gets current page value.
+   *
+   * @return string|NULL
+   */
+  public function getPage() {
+    return $this->page;
+  }
+
+  /**
+   * Sets current page value.
+   *
+   * @param string $value
+   */
+  public function setPage($value) {
+    $this->page = $value;
+  }
+
+  /**
+   * Gets current pivotCount value.
+   *
+   * @return string|NULL
+   */
+  public function getPivotCount() {
+    return $this->pivotCount;
+  }
+
+  /**
+   * Sets current pivotCount value.
+   *
+   * @param string $value
+   */
+  public function setPivotCount($value) {
+    $this->pivotCount = $value;
+  }
+}

--- a/CRM/PivotData/AbstractData.php
+++ b/CRM/PivotData/AbstractData.php
@@ -236,12 +236,14 @@ abstract class CRM_PivotData_AbstractData implements CRM_PivotData_DataInterface
   /**
    * @inheritdoc
    */
-  public function rebuildCachePartial(AbstractGroup $cacheGroup, array $params, $offset, $multiValuesOffset, $index, $page, $pivotCount) {
+  public function rebuildCachePartial(AbstractGroup $cacheGroup, array $params, $offset, $multiValuesOffset, $index, $page, $pivotCount, $clear = TRUE) {
     $this->emptyRow = $this->getEmptyRow();
     $this->multiValues = array();
 
     if (!$offset) {
-      $cacheGroup->clear();
+      if ($clear) {
+        $cacheGroup->clear();
+      }
 
       $totalCount = $this->getCount($params);
       $this->rebuildEntityCount($cacheGroup, $totalCount);

--- a/CRM/PivotData/AbstractData.php
+++ b/CRM/PivotData/AbstractData.php
@@ -254,6 +254,9 @@ abstract class CRM_PivotData_AbstractData implements CRM_PivotData_DataInterface
     if (!$result['count']) {
       $this->rebuildHeader($cacheGroup, array_merge($this->emptyRow, $this->additionalHeaderFields));
       $this->rebuildPivotCount($cacheGroup, $pivotCount);
+
+      CRM_PivotReport_BAO_PivotReportCache::deleteActiveCache($cacheGroup->getName());
+      CRM_PivotReport_BAO_PivotReportCache::activateCache($cacheGroup->getName());
     }
 
     return $result;
@@ -815,6 +818,15 @@ abstract class CRM_PivotData_AbstractData implements CRM_PivotData_DataInterface
     ));
 
     return $result['values'];
+  }
+
+  /**
+   * Returns name property value.
+   *
+   * @return string
+   */
+  public function getName() {
+    return $this->name;
   }
 
   /**

--- a/CRM/PivotData/DataInterface.php
+++ b/CRM/PivotData/DataInterface.php
@@ -41,10 +41,11 @@ interface CRM_PivotData_DataInterface {
    * @param string $index
    * @param int $page
    * @param int $pivotCount
+   * @param bool $clear
    *
    * @return array
    */
-  public function rebuildCachePartial(AbstractGroup $cacheGroup, array $params, $offset, $multiValuesOffset, $index, $page, $pivotCount);
+  public function rebuildCachePartial(AbstractGroup $cacheGroup, array $params, $offset, $multiValuesOffset, $index, $page, $pivotCount, $clear = TRUE);
 
   /**
    * Rebuilds entity data cache using entity paginated results.

--- a/CRM/PivotReport/BAO/PivotReportCache.php
+++ b/CRM/PivotReport/BAO/PivotReportCache.php
@@ -54,8 +54,6 @@ class CRM_PivotReport_BAO_PivotReportCache extends CRM_PivotReport_DAO_PivotRepo
 
     $cacheBuilt = FALSE;
     if (!$status->getEntity()) {
-      self::deleteActiveCache();
-      self::activateCache();
       self::updateBuildDatetime();
       $cacheBuilt = TRUE;
     }
@@ -201,34 +199,34 @@ class CRM_PivotReport_BAO_PivotReportCache extends CRM_PivotReport_DAO_PivotRepo
 
   /**
    * Deletes all active cache of Pivot Report entities data.
+   *
+   * @param string $group
    */
-  public static function deleteActiveCache() {
+  public static function deleteActiveCache($group = NULL) {
     $table = self::getTableName();
-    $where = self::whereActiveCache();
+    $where = 'group_name <> "admin" AND is_active = 1';
+
+    if ($group) {
+      $where .= ' AND group_name = "' . CRM_Core_DAO::escapeString($group) . '"';
+    }
 
     CRM_Core_DAO::executeQuery("DELETE FROM $table WHERE $where");
   }
 
   /**
-   * Composes a SQL WHERE clause for the active cache.
-   *
-   * @return string
-   */
-  private static function whereActiveCache() {
-    $clauses = array();
-    $clauses[] = 'group_name <> "admin"';
-    $clauses[] = 'is_active = 1';
-
-    return implode(' AND ', $clauses);
-  }
-
-  /**
    * Sets 'is_active' values to 1 for all cache rows.
+   *
+   * @param string $group
    */
-  private static function activateCache() {
+  public static function activateCache($group = NULL) {
     $table = self::getTableName();
+    $where = "group_name <> 'admin'";
 
-    CRM_Core_DAO::executeQuery("UPDATE $table SET is_active = 1 WHERE group_name <> 'admin'");
+    if ($group) {
+      $where .= ' AND group_name = "' . CRM_Core_DAO::escapeString($group) . '"';
+    }
+
+    CRM_Core_DAO::executeQuery("UPDATE $table SET is_active = 1 WHERE $where");
   }
 
   /**

--- a/CRM/PivotReport/DAO/PivotReportCache.php
+++ b/CRM/PivotReport/DAO/PivotReportCache.php
@@ -87,6 +87,12 @@ class CRM_PivotReport_DAO_PivotReportCache extends CRM_Core_DAO {
    */
   public $expired_date;
   /**
+   * Is the cache entry active?
+   *
+   * @var boolean
+   */
+  public $is_active;
+  /**
    * Class constructor.
    */
   function __construct() {
@@ -164,6 +170,18 @@ class CRM_PivotReport_DAO_PivotReportCache extends CRM_Core_DAO {
           'description' => 'When should the cache item expire',
           'required' => false,
           'default' => 'NULL',
+          'table_name' => 'civicrm_pivotreportcache',
+          'entity' => 'PivotReportCache',
+          'bao' => 'CRM_PivotReport_DAO_PivotReportCache',
+          'localizable' => 0,
+        ) ,
+        'is_active' => array(
+          'name' => 'is_active',
+          'type' => CRM_Utils_Type::T_BOOLEAN,
+          'title' => ts('Is active?') ,
+          'description' => 'Is the cache entry active?',
+          'required' => false,
+          'default' => 0,
           'table_name' => 'civicrm_pivotreportcache',
           'entity' => 'PivotReportCache',
           'bao' => 'CRM_PivotReport_DAO_PivotReportCache',

--- a/CRM/PivotReport/Upgrader.php
+++ b/CRM/PivotReport/Upgrader.php
@@ -16,6 +16,7 @@ class CRM_PivotReport_Upgrader extends CRM_PivotReport_Upgrader_Base {
     $this->upgrade_0003();
     $this->upgrade_0006();
     $this->upgrade_0007();
+    $this->upgrade_0009();
 
     return TRUE;
   }
@@ -206,6 +207,18 @@ class CRM_PivotReport_Upgrader extends CRM_PivotReport_Upgrader_Base {
 
       CRM_Core_BAO_Navigation::resetNavigation();
     }
+
+    return TRUE;
+  }
+
+  /**
+   * Adds 'is_active' field into 'civicrm_pivotreportcache' table and
+   * sets its value to '1' for all existing cache rows.
+   *
+   * @return boolean
+   */
+  public function upgrade_0009() {
+    $this->executeSqlFile('sql/civicrm_pivotreportcache_is_active.sql');
 
     return TRUE;
   }

--- a/api/v3/PivotReport.php
+++ b/api/v3/PivotReport.php
@@ -84,6 +84,22 @@ function civicrm_api3_pivot_report_rebuildcache($params) {
 }
 
 /**
+ * PivotReport.rebuildcachecronjob API
+ *
+ * @param array $params
+ * @return array API result descriptor
+ * @throws API_Exception
+ */
+function civicrm_api3_pivot_report_rebuildcachecronjob($params) {
+  $result = CRM_PivotReport_BAO_PivotReportCache::rebuildCacheCronJob();
+
+  return civicrm_api3_create_success(
+    array($result),
+    $params
+  );
+}
+
+/**
  * PivotReport.rebuildcachepartial API
  *
  * @param array $params

--- a/sql/civicrm_pivotreportcache_is_active.sql
+++ b/sql/civicrm_pivotreportcache_is_active.sql
@@ -1,3 +1,12 @@
+-- Add 'is_active' column into Pivot Cache table.
 ALTER TABLE `civicrm_pivotreportcache` ADD `is_active` TINYINT(1) UNSIGNED NOT NULL DEFAULT '0' AFTER `expired_date`;
 
+-- Update 'is_active' value to 1 for each currently existing Pivot Cache row.
 UPDATE `civicrm_pivotreportcache` SET is_active = 1;
+
+-- Drop existing unique indexes to allow having the same group name and path.
+ALTER TABLE `civicrm_pivotreportcache` DROP INDEX `UI_group_path`;
+ALTER TABLE `civicrm_pivotreportcache` DROP INDEX `UI_group_path_date`;
+
+-- Add unique index to require unique group name, path and is_active values.
+ALTER TABLE `civicrm_pivotreportcache` ADD UNIQUE INDEX `UI_group_path_active` (`group_name`, `path`, `is_active`);

--- a/sql/civicrm_pivotreportcache_is_active.sql
+++ b/sql/civicrm_pivotreportcache_is_active.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `civicrm_pivotreportcache` ADD `is_active` TINYINT(1) UNSIGNED NOT NULL DEFAULT '0' AFTER `expired_date`;
+
+UPDATE `civicrm_pivotreportcache` SET is_active = 1;

--- a/sql/civicrm_pivotreportcache_is_active.sql
+++ b/sql/civicrm_pivotreportcache_is_active.sql
@@ -2,7 +2,7 @@
 ALTER TABLE `civicrm_pivotreportcache` ADD `is_active` TINYINT(1) UNSIGNED NOT NULL DEFAULT '0' AFTER `expired_date`;
 
 -- Update 'is_active' value to 1 for each currently existing Pivot Cache row.
-UPDATE `civicrm_pivotreportcache` SET is_active = 1;
+UPDATE `civicrm_pivotreportcache` SET is_active = 1 WHERE group_name <> 'admin';
 
 -- Drop existing unique indexes to allow having the same group name and path.
 ALTER TABLE `civicrm_pivotreportcache` DROP INDEX `UI_group_path`;

--- a/xml/schema/CRM/PivotReport/PivotReportCache.xml
+++ b/xml/schema/CRM/PivotReport/PivotReportCache.xml
@@ -72,5 +72,14 @@
     <comment>When should the cache item expire</comment>
     <add>4.7</add>
   </field>
+  <field>
+    <name>is_active</name>
+    <title>Is active?</title>
+    <type>boolean</type>
+    <default>0</default>
+    <required>false</required>
+    <comment>Is the cache entry active?</comment>
+    <add>4.7</add>
+  </field>
 
 </table>


### PR DESCRIPTION
This PR adds new 'rebuildcachecronjob' API action for PivotReport entity.

It doesn't require any parameters (it automatically walks through available Pivot Report entities and caches further data on each run). It uses 'lock' property so there is no overlapping when running the action before previous run is finished.

Caching is stored as 'non-active' until whole cache is built. Then the cache is marked as 'active' and is used by Pivot Reports. This way we can build the cache without harming the existing one and use Pivot Reports with previously built cache without waiting until current build process is complete.

The action can be add into CiviCRM scheduled jobs to run repeatedly. Each run caches one chunk of Pivot Report data and saves information (such as offset, index, page) needed for next run to cache further Pivot Report data.

The action can also be executed with drush or API explorer (for testing purposes) to see its results.

The action returns an array such as:

    "values": [
        {
            "entity": "Contribution",
            "offset": 128,
            "multiValuesOffset": 0,
            "time": 0.71826481819153,
            "cacheBuilt": false
        }
    ]

'entity' is the name of the next processed entity
'offset' is the offset of the next processed entity
'multiValuesOffset' is the multiValuesOffset of the next processed entity
'time' is the time (in seconds) required to complete latest run
'cacheBuilt' says if whole cache is built after latest run

If the cache is completely built, the action response looks like below:

    "values": [
        {
            "entity": null,
            "offset": 0,
            "multiValuesOffset": 0,
            "time": 0.27362394332886,
            "cacheBuilt": true
        }
    ]

('entity' becomes null and 'cacheBuilt' is true)

If the action is run before previously action finishes then the response is simply null:

    "values": [
        null
    ]

After whole cache is built it is set as 'active' (so the Pivot Report is using it) and next run starts over the caching process.