### PR TITLE
HW-433: Setting Option Value as field value if Option Label is not available

### DIFF
--- a/CRM/PivotData/AbstractData.php
+++ b/CRM/PivotData/AbstractData.php
@@ -673,7 +673,11 @@ abstract class CRM_PivotData_AbstractData implements CRM_PivotData_DataInterface
       // such as 'CheckBox' (looks like they aren't implemented there) so
       // we deal with them automatically by custom handling of 'optionValues' array.
       case !empty($fields[$key]['optionValues']):
-        $result = $fields[$key]['optionValues'][$value];
+        if (isset($fields[$key]['optionValues'][$value])) {
+          $result = $fields[$key]['optionValues'][$value];
+        } else {
+          $result = $value;
+        }
         break;
 
       // Protect string values from line-breaks


### PR DESCRIPTION
Setting Option Value as field value if Option Label is not available (in case that some Options are removed from Option Group).