### PR TITLE
HW-433: Implementing cache source field

### DIFF
--- a/CRM/PivotCache/AbstractGroup.php
+++ b/CRM/PivotCache/AbstractGroup.php
@@ -14,8 +14,16 @@ abstract class CRM_PivotCache_AbstractGroup implements CRM_PivotCache_GroupInter
    */
   protected $name = NULL;
 
-  public function __construct($name = NULL) {
+  /**
+   * Source of cache group.
+   *
+   * @var int
+   */
+  protected $source = NULL;
+
+  public function __construct($name, $source) {
     $this->name = 'pivotreport.' . $name;
+    $this->source = $source;
   }
 
   /**
@@ -44,10 +52,19 @@ abstract class CRM_PivotCache_AbstractGroup implements CRM_PivotCache_GroupInter
   }
 
   /**
+   * Gets cache group source.
+   *
+   * @return string
+   */
+  public function getSource() {
+    return $this->source;
+  }
+
+  /**
    * @inheritdoc
    */
   public function clear() {
-    CRM_PivotReport_BAO_PivotReportCache::deleteGroup($this->getName());
+    CRM_PivotReport_BAO_PivotReportCache::deleteGroup($this->getName(), NULL, $this->source);
   }
 
   /**
@@ -69,7 +86,7 @@ abstract class CRM_PivotCache_AbstractGroup implements CRM_PivotCache_GroupInter
    * @inheritdoc
    */
   public function setCacheValue($key, $value) {
-    CRM_PivotReport_BAO_PivotReportCache::setItem($value, $this->getName(), $key);
+    CRM_PivotReport_BAO_PivotReportCache::setItem($value, $this->getName(), $key, $this->source);
   }
 
   /**

--- a/CRM/PivotCache/GroupActivity.php
+++ b/CRM/PivotCache/GroupActivity.php
@@ -5,8 +5,8 @@
  */
 class CRM_PivotCache_GroupActivity extends CRM_PivotCache_AbstractGroup {
 
-  public function __construct($name = NULL) {
-    parent::__construct('Activity');
+  public function __construct($name = NULL, $source = NULL) {
+    parent::__construct('Activity', $source);
   }
 
   /**

--- a/CRM/PivotCache/GroupCase.php
+++ b/CRM/PivotCache/GroupCase.php
@@ -5,7 +5,7 @@
  */
 class CRM_PivotCache_GroupCase extends CRM_PivotCache_AbstractGroup {
 
-  public function __construct($name = NULL) {
-    parent::__construct('Case');
+  public function __construct($name = NULL, $source = NULL) {
+    parent::__construct('Case', $source);
   }
 }

--- a/CRM/PivotCache/GroupContribution.php
+++ b/CRM/PivotCache/GroupContribution.php
@@ -5,7 +5,7 @@
  */
 class CRM_PivotCache_GroupContribution extends CRM_PivotCache_AbstractGroup {
 
-  public function __construct($name = NULL) {
-    parent::__construct('Contribution');
+  public function __construct($name = NULL, $source = NULL) {
+    parent::__construct('Contribution', $source);
   }
 }

--- a/CRM/PivotCache/GroupMembership.php
+++ b/CRM/PivotCache/GroupMembership.php
@@ -5,7 +5,7 @@
  */
 class CRM_PivotCache_GroupMembership extends CRM_PivotCache_AbstractGroup {
 
-  public function __construct($name = NULL) {
-    parent::__construct('Membership');
+  public function __construct($name = NULL, $source = NULL) {
+    parent::__construct('Membership', $source);
   }
 }

--- a/CRM/PivotCache/GroupProspect.php
+++ b/CRM/PivotCache/GroupProspect.php
@@ -5,7 +5,7 @@
  */
 class CRM_PivotCache_GroupProspect extends CRM_PivotCache_AbstractGroup {
 
-  public function __construct($name = NULL) {
-    parent::__construct('Prospect');
+  public function __construct($name = NULL, $source = NULL) {
+    parent::__construct('Prospect', $source);
   }
 }

--- a/CRM/PivotData/AbstractData.php
+++ b/CRM/PivotData/AbstractData.php
@@ -224,8 +224,7 @@ abstract class CRM_PivotData_AbstractData implements CRM_PivotData_DataInterface
     $this->rebuildPivotCount($cacheGroup, $result['count']);
 
     CRM_PivotReport_BAO_PivotReportCache::deleteActiveCache($cacheGroup->getName());
-    CRM_PivotReport_BAO_PivotReportCache::activateCache($cacheGroup->getName());
-    CRM_PivotReport_BAO_PivotReportCache::updateBuildDatetime();
+    CRM_PivotReport_BAO_PivotReportCache::activateCache($cacheGroup);
 
     return array(
       array(
@@ -238,14 +237,12 @@ abstract class CRM_PivotData_AbstractData implements CRM_PivotData_DataInterface
   /**
    * @inheritdoc
    */
-  public function rebuildCachePartial(AbstractGroup $cacheGroup, array $params, $offset, $multiValuesOffset, $index, $page, $pivotCount, $clear = TRUE) {
+  public function rebuildCachePartial(AbstractGroup $cacheGroup, array $params, $offset, $multiValuesOffset, $index, $page, $pivotCount) {
     $this->emptyRow = $this->getEmptyRow();
     $this->multiValues = array();
 
-    if (!$offset) {
-      if ($clear) {
-        $cacheGroup->clear();
-      }
+    if (!$offset && !$multiValuesOffset) {
+      $cacheGroup->clear();
 
       $totalCount = $this->getCount($params);
       $this->rebuildEntityCount($cacheGroup, $totalCount);
@@ -258,7 +255,7 @@ abstract class CRM_PivotData_AbstractData implements CRM_PivotData_DataInterface
       $this->rebuildPivotCount($cacheGroup, $pivotCount);
 
       CRM_PivotReport_BAO_PivotReportCache::deleteActiveCache($cacheGroup->getName());
-      CRM_PivotReport_BAO_PivotReportCache::activateCache($cacheGroup->getName());
+      CRM_PivotReport_BAO_PivotReportCache::activateCache($cacheGroup);
     }
 
     return $result;

--- a/CRM/PivotData/DataInterface.php
+++ b/CRM/PivotData/DataInterface.php
@@ -41,11 +41,10 @@ interface CRM_PivotData_DataInterface {
    * @param string $index
    * @param int $page
    * @param int $pivotCount
-   * @param bool $clear
    *
    * @return array
    */
-  public function rebuildCachePartial(AbstractGroup $cacheGroup, array $params, $offset, $multiValuesOffset, $index, $page, $pivotCount, $clear = TRUE);
+  public function rebuildCachePartial(AbstractGroup $cacheGroup, array $params, $offset, $multiValuesOffset, $index, $page, $pivotCount);
 
   /**
    * Rebuilds entity data cache using entity paginated results.

--- a/CRM/PivotReport/DAO/PivotReportCache.php
+++ b/CRM/PivotReport/DAO/PivotReportCache.php
@@ -93,6 +93,12 @@ class CRM_PivotReport_DAO_PivotReportCache extends CRM_Core_DAO {
    */
   public $is_active;
   /**
+   * Source of the cache row
+   *
+   * @var int
+   */
+  public $source;
+  /**
    * Class constructor.
    */
   function __construct() {
@@ -182,6 +188,18 @@ class CRM_PivotReport_DAO_PivotReportCache extends CRM_Core_DAO {
           'description' => 'Is the cache entry active?',
           'required' => false,
           'default' => 0,
+          'table_name' => 'civicrm_pivotreportcache',
+          'entity' => 'PivotReportCache',
+          'bao' => 'CRM_PivotReport_DAO_PivotReportCache',
+          'localizable' => 0,
+        ) ,
+        'source' => array(
+          'name' => 'source',
+          'type' => CRM_Utils_Type::T_INT,
+          'title' => ts('Source of the cache row') ,
+          'description' => 'Source of the cache row (1 - Drush rebuildcache, 2 - Drush rebuildcachecronjob, 3 - PivotReport Admin UI)',
+          'required' => false,
+          'default' => 'NULL',
           'table_name' => 'civicrm_pivotreportcache',
           'entity' => 'PivotReportCache',
           'bao' => 'CRM_PivotReport_DAO_PivotReportCache',

--- a/CRM/PivotReport/Entity.php
+++ b/CRM/PivotReport/Entity.php
@@ -230,15 +230,17 @@ class CRM_PivotReport_Entity {
    * Returns an instance of CRM_PivotCache_AbstractGroup for entityName property
    * value.
    *
+   * @param int $source
+   *
    * @return \CRM_PivotCache_AbstractGroup
    * @throws Exception
    */
-  public function getGroupInstance() {
+  public function getGroupInstance($source = NULL) {
     $className = 'CRM_PivotCache_Group' . $this->entityName;
     if (!class_exists($className)) {
       throw new Exception("Class '{$className}' does not exist. It should exist and extend CRM_PivotCache_AbstractGroup class.");
     }
 
-    return new $className();
+    return new $className(NULL, $source);
   }
 }

--- a/CRM/PivotReport/Upgrader.php
+++ b/CRM/PivotReport/Upgrader.php
@@ -224,6 +224,17 @@ class CRM_PivotReport_Upgrader extends CRM_PivotReport_Upgrader_Base {
   }
 
   /**
+   * Adds 'source' field into 'civicrm_pivotreportcache' table.
+   *
+   * @return boolean
+   */
+  public function upgrade_0010() {
+    $this->executeSqlFile('sql/civicrm_pivotreportcache_source.sql');
+
+    return TRUE;
+  }
+
+  /**
    * Creates new menu item using provided parameters.
    *
    * @param array $params

--- a/api/v3/PivotReport.php
+++ b/api/v3/PivotReport.php
@@ -72,10 +72,12 @@ function civicrm_api3_pivot_report_rebuildcache($params) {
   foreach ($entities as $entity) {
     $entityInstance = new CRM_PivotReport_Entity($entity);
     $result[$entity] = $entityInstance->getDataInstance()->rebuildCache(
-      $entityInstance->getGroupInstance(),
+      $entityInstance->getGroupInstance(CRM_PivotReport_BAO_PivotReportCache::SOURCE_REBUILDCACHE),
       array()
     );
   }
+
+  CRM_PivotReport_BAO_PivotReportCache::updateBuildDatetime();
 
   return civicrm_api3_create_success(
     $result,
@@ -116,7 +118,7 @@ function civicrm_api3_pivot_report_rebuildcachepartial($params) {
 
   $entityInstance = new CRM_PivotReport_Entity($entity);
   $result = $entityInstance->getDataInstance()->rebuildCachePartial(
-    $entityInstance->getGroupInstance(),
+    $entityInstance->getGroupInstance(CRM_PivotReport_BAO_PivotReportCache::SOURCE_UI),
     $params,
     $offset,
     $multiValuesOffset,

--- a/sql/civicrm_pivotreportcache_source.sql
+++ b/sql/civicrm_pivotreportcache_source.sql
@@ -1,0 +1,8 @@
+-- Add 'source' column into Pivot Cache table.
+ALTER TABLE `civicrm_pivotreportcache` ADD `source` INT(3) UNSIGNED NULL DEFAULT NULL COMMENT 'Source of the cache row (1 - Drush rebuildcache, 2 - Drush rebuildcachecronjob, 3 - PivotReport Admin UI)' AFTER `expired_date`;
+
+-- Drop existing unique indexes to allow having the same group name, path and active values.
+ALTER TABLE `civicrm_pivotreportcache` DROP INDEX `UI_group_path_active`;
+
+-- Add unique index to require unique group name, path, is_active and source values.
+ALTER TABLE `civicrm_pivotreportcache` ADD UNIQUE INDEX `UI_group_path_active_source` (`group_name`, `path`, `is_active`, `source`);

--- a/xml/schema/CRM/PivotReport/PivotReportCache.xml
+++ b/xml/schema/CRM/PivotReport/PivotReportCache.xml
@@ -81,5 +81,13 @@
     <comment>Is the cache entry active?</comment>
     <add>4.7</add>
   </field>
+  <field>
+    <name>source</name>
+    <title>Source of the cache row</title>
+    <type>int unsigned</type>
+    <required>false</required>
+    <comment>Source of the cache row (1 - Drush rebuildcache, 2 - Drush rebuildcachecronjob, 3 - PivotReport Admin UI)</comment>
+    <add>4.7</add>
+  </field>
 
 </table>


### PR DESCRIPTION
Adding 'source' field into Pivot Report cache to distinguish three different actions of cache rebuilding (single action rebuilding whole cache, cron job action rebuilding cache chunk, UI action). This allows to separate inactive cache (by its source) and preserves from wiping partially built cache by other cache build action with different source.